### PR TITLE
`no-renaming-operator` rule modification

### DIFF
--- a/packages/eslint-plugin-choreography-ts/src/no-outside-choreographic-operator.ts
+++ b/packages/eslint-plugin-choreography-ts/src/no-outside-choreographic-operator.ts
@@ -28,7 +28,7 @@ const noOutsideOperatorRule: TSESLint.RuleModule<MessageIDs, []> = {
     hasSuggestions: true, // provide suggestions for fixes
     messages: {
       error:
-        "Choreographic operator '{{ operator }}' must be provided by closest enclosing context",
+        "Choreographic operator '{{ operator }}' must be provided by closest enclosing context.",
       suggestion: "Add missing operator `{{ operator }}` to dependencies",
     },
     schema: [],

--- a/packages/eslint-plugin-choreography-ts/tests/no-renaming-operator.test.ts
+++ b/packages/eslint-plugin-choreography-ts/tests/no-renaming-operator.test.ts
@@ -58,5 +58,29 @@ ruleTester.run("no-renaming-operator", noRenameRule, {
         },
       ],
     },
+    {
+      name: "test for error in choreography as an argument",
+      code: `
+      type Locations = "alice" | "bob" | "carol";
+      const _test: Choreography<Locations> = async ({ colocally }) => {
+        await colocally(
+          ["alice", "bob"],
+          async ({ locally: l }) => {
+            await l("alice", () => {
+              console.log("Alice here");
+              return [];
+            });
+            return [];
+          },
+          []
+        );
+        return [];
+      };`,
+      errors: [
+        {
+          messageId: "rename",
+        },
+      ],
+    },
   ],
 });


### PR DESCRIPTION
Modified `no-renaming-operator` rule to apply to choreographies as arguments, and made style-conforming changes to linting messages