### PR TITLE
Fault Tolerance

### DIFF
--- a/packages/core/src/core.ts
+++ b/packages/core/src/core.ts
@@ -202,8 +202,21 @@ export function parcelFromJSON<L extends Location>(json: string): Parcel<L> {
   return parcel;
 }
 
+/**
+ * A log manager is responsible for saving and loading logged values from a persistent storage for fault tolerance.
+ */
 export interface LogManager {
+  /**
+   * Write a value to the log
+   * @param lid the identifier of the log entry
+   * @param data data to be written
+   */
   write<T>(lid: string, data: T): Promise<void>;
+  /**
+   * Read a value from the log
+   * @param lid the identifier of the log entry
+   * @returns a promise that resolves the object with the `ok` field, which is `true` if the log entry exists, and `false` otherwise.
+   */
   read<T>(lid: string): Promise<{ ok: true; value: T } | { ok: false }>;
 }
 

--- a/packages/core/src/in-memory-log-manager.test.ts
+++ b/packages/core/src/in-memory-log-manager.test.ts
@@ -1,0 +1,18 @@
+import { InMemoryLogManager } from "./in-memory-log-manager";
+
+describe("InMemoryLogManager", () => {
+  test("write and read", async () => {
+    const lm = new InMemoryLogManager();
+    const lid = "test-lid";
+    const data = { foo: "bar" };
+    await lm.write(lid, data);
+    const result = await lm.read(lid);
+    expect(result).toEqual({ ok: true, value: data });
+  });
+  test("read missing", async () => {
+    const lm = new InMemoryLogManager();
+    const lid = "test-lid";
+    const result = await lm.read(lid);
+    expect(result).toEqual({ ok: false });
+  });
+});

--- a/packages/core/src/in-memory-log-manager.ts
+++ b/packages/core/src/in-memory-log-manager.ts
@@ -1,5 +1,8 @@
 import { LogManager } from "./core.js";
 
+/**
+ * In-memory log manager stores logs in memory. Note that memory is not persisted and this should only be used for testing.
+ */
 export class InMemoryLogManager implements LogManager {
   private dict: Record<string, string> = {};
   async write<T>(lid: string, data: T): Promise<void> {

--- a/packages/core/src/in-memory-log-manager.ts
+++ b/packages/core/src/in-memory-log-manager.ts
@@ -1,0 +1,15 @@
+import { LogManager } from "./core.js";
+
+export class InMemoryLogManager implements LogManager {
+  private dict: Record<string, string> = {};
+  async write<T>(lid: string, data: T): Promise<void> {
+    this.dict[lid] = JSON.stringify(data);
+  }
+  async read<T>(lid: string): Promise<{ ok: true; value: T } | { ok: false }> {
+    const s = this.dict[lid];
+    if (s === undefined) {
+      return { ok: false };
+    }
+    return { ok: true, value: JSON.parse(s) };
+  }
+}


### PR DESCRIPTION
This PR adds a minimal fault tolerance feature that can tolerate a node crashing and restarting. We do so by recording the return values of each choreographic operator and saving log entries to the persistent storage. Each operator also checks if there is a log entry in the log, and if it finds that the operator has already been executed, it returns the saved value and does not execute the actual behavior. This makes it possible to "recover" the program state at the point of the crash and continue as if the crash didn't happen. The other locations are expected to be waiting for the crashing node to come back up.