### PR TITLE
Lottery example

### DIFF
--- a/packages/core/src/core.test.ts
+++ b/packages/core/src/core.test.ts
@@ -71,7 +71,7 @@ describe("core", () => {
         const msgAtSelectedTwo = await multicast(
           "alice",
           ["bob", "carol"],
-          msg
+          msg,
         );
         await locally("bob", (unwrap) => {
           expect(unwrap(msgAtSelectedTwo)).toBe("Hello, world!");
@@ -104,7 +104,7 @@ describe("core", () => {
             check = naked(mlv);
             return [];
           },
-          []
+          [],
         );
       };
       const g = runner.compile(test);
@@ -134,7 +134,7 @@ describe("core", () => {
             expect(msg).toBe("Hello, world!");
             count += 1;
           },
-          void 0
+          void 0,
         );
       };
       const g = runner.compile(test);

--- a/packages/core/src/core.test.ts
+++ b/packages/core/src/core.test.ts
@@ -1,6 +1,6 @@
 import { describe, test, expect } from "vitest";
 
-import { Choreography, Located, Runner } from "./core";
+import { Choreography, MultiplyLocated, Runner } from "./core";
 
 const runner = new Runner();
 
@@ -13,7 +13,7 @@ describe("core", () => {
       const choreography: Choreography<
         "alice" | "bob",
         [],
-        [Located<string, "bob">]
+        [MultiplyLocated<string, "bob">]
       > = async ({ locally, comm }) => {
         const msg = await locally("alice", () => "Hello, world!");
         const msgAtBob = await comm("alice", "bob", msg);
@@ -22,7 +22,7 @@ describe("core", () => {
 
       const f = runner.compile(choreography);
       const [msgAtBob] = await f([]);
-      expect(msgAtBob).toEqual("Hello, world!");
+      expect(runner.unwrap(msgAtBob)).toEqual("Hello, world!");
     });
     test("Global arguments", async () => {
       const p = "GLOBAL ARGUMENT";
@@ -38,17 +38,16 @@ describe("core", () => {
     });
     test("Located arguments", async () => {
       const p = "Alice's Secret Message";
-      const c: Choreography<Locations, [Located<string, "alice">]> = async (
-        { locally },
-        [msg],
-      ) => {
+      const c: Choreography<
+        Locations,
+        MultiplyLocated<string, "alice">
+      > = async ({ locally }, msg) => {
         await locally("alice", (unwrap) => {
           expect(unwrap(msg)).toBe(p);
         });
-        return [];
       };
       const g = runner.compile(c);
-      await g([p]);
+      await g(runner.local(p));
     });
     test("Async locally", async () => {
       let count = 0;
@@ -60,10 +59,9 @@ describe("core", () => {
           expect(unwrap(msg)).toBe(5);
           count += 1;
         });
-        return [];
       };
       const g = runner.compile(c);
-      await g([]);
+      await g(void 0);
       expect(count).toBe(1);
     });
     test("multicast", async () => {
@@ -73,7 +71,7 @@ describe("core", () => {
         const msgAtSelectedTwo = await multicast(
           "alice",
           ["bob", "carol"],
-          msg,
+          msg
         );
         await locally("bob", (unwrap) => {
           expect(unwrap(msgAtSelectedTwo)).toBe("Hello, world!");
@@ -83,10 +81,9 @@ describe("core", () => {
           expect(unwrap(msgAtSelectedTwo)).toBe("Hello, world!");
           count += 1;
         });
-        return [];
       };
       const g = runner.compile(test);
-      await g([]);
+      await g(void 0);
       expect(count).toBe(2);
     });
     test("naked", async () => {
@@ -107,12 +104,11 @@ describe("core", () => {
             check = naked(mlv);
             return [];
           },
-          [],
+          []
         );
-        return [];
       };
       const g = runner.compile(test);
-      await g([]);
+      await g(void 0);
       expect(check).toBe("Hello, world!");
     });
     test("broadcast", async () => {
@@ -122,10 +118,9 @@ describe("core", () => {
         const msg = await broadcast("alice", localMsg);
         expect(msg).toBe("Hello everyone!");
         count += 1;
-        return [];
       };
       const g = runner.compile(test);
-      await g([]);
+      await g(void 0);
       expect(count).toBe(1);
     });
     test("enclave", async () => {
@@ -138,14 +133,12 @@ describe("core", () => {
             const msg = await broadcast("bob", msgAtBob);
             expect(msg).toBe("Hello, world!");
             count += 1;
-            return [];
           },
-          [],
+          void 0
         );
-        return [];
       };
       const g = runner.compile(test);
-      await g([]);
+      await g(void 0);
       expect(count).toBe(1);
     });
   });

--- a/packages/core/src/core.ts
+++ b/packages/core/src/core.ts
@@ -62,7 +62,14 @@ export class MultiplyLocated<T, L extends Location> {
   }
   protected value: T;
   protected key: symbol;
-  protected phantom?: (x: L) => void;
+
+  // both are required to avoid subtype relations
+  protected phantom1?: (_: L) => void;
+  protected phantom2?: L;
+
+  protected static remote<T, L extends Location>(): MultiplyLocated<T, L> {
+    return new MultiplyLocated(undefined as any, undefined as any);
+  }
 }
 
 export class Faceted<T, L extends Location> {
@@ -106,10 +113,10 @@ export type Dependencies<L extends Location> = {
 export type Locally<L extends Location> = <L1 extends L, T>(
   location: L1,
   callback: (unwrap: Unwrap<L1>) => T | Promise<T>
-) => Promise<Located<T, L1>>;
+) => Promise<MultiplyLocated<T, L1>>;
 
-export type Unwrap<L1 extends Location> = <T>(
-  located: Located<T, L1> | MultiplyLocated<T, L1> | Faceted<T, L1>
+export type Unwrap<L1 extends Location> = <S extends Location, T>(
+  located: (L1 extends S ? MultiplyLocated<T, S> : never) | Faceted<T, L1>
 ) => T;
 
 /**
@@ -118,18 +125,14 @@ export type Unwrap<L1 extends Location> = <T>(
 export type Comm<L extends Location> = <L1 extends L, L2 extends L, T>(
   sender: L1,
   receiver: L2,
-  value: Located<T, L1>
-) => Promise<Located<T, L2>>;
+  value: MultiplyLocated<T, L1>
+) => Promise<MultiplyLocated<T, L2>>;
 
-export type Enclave<L extends Location> = <
-  LL extends L,
-  Args extends Located<any, LL>[],
-  Return extends Located<any, LL>[],
->(
+export type Enclave<L extends Location> = <LL extends L, Args, Return>(
   locations: LL[],
   choreography: Choreography<LL, Args, Return>,
   args: Args
-) => Promise<Return>;
+) => Promise<MultiplyLocated<Return, LL>>;
 
 export type Naked<L extends Location> = <T>(mlv: MultiplyLocated<T, L>) => T;
 
@@ -140,22 +143,18 @@ export type Multicast<L extends Location> = <
 >(
   sender: L1,
   receivers: LL[],
-  value: Located<T, L1>
+  value: Located<T, L1> | Faceted<T, L1> | MultiplyLocated<T, L1>
 ) => Promise<MultiplyLocated<T, LL | L1>>;
 
 /**
  * Broadcast a value of type `T` from location `L1` to all other locations
  */
-export type Broadcast<L extends Location> = <L1 extends L, T>(
+export type Broadcast<L extends Location> = <S extends L, L1 extends L, T>(
   sender: L1,
-  value: Located<T, L1>
+  value: L1 extends S ? MultiplyLocated<T, S> : never
 ) => Promise<T>;
 
-export type Call<L extends Location> = <
-  LL extends L,
-  Args extends Located<any, LL>[],
-  Return extends Located<any, LL>[],
->(
+export type Call<L extends Location> = <LL extends L, Args, Return>(
   choreography: Choreography<LL, Args, Return>,
   args: Args
 ) => Promise<Return>;
@@ -167,7 +166,7 @@ export type Parallel<L extends Location> = <const QS extends L, T>(
 
 export type FanOut<L extends Location> = <QS extends L, T>(
   locations: QS[],
-  c: <Q extends QS>(q: Q) => Choreography<L, [], [Located<T, Q>]>
+  c: <Q extends QS>(q: Q) => Choreography<L, undefined, MultiplyLocated<T, QS>>
 ) => Promise<Faceted<T, QS>>;
 
 export type FanIn<L extends Location> = <
@@ -177,44 +176,22 @@ export type FanIn<L extends Location> = <
 >(
   participants: QS[],
   recipients: RS[],
-  c: <Q extends QS>(loc: Q) => Choreography<L, [], [Located<T, RS>]>
+  c: <Q extends QS>(loc: Q) => Choreography<L, [], MultiplyLocated<T, RS>>
 ) => Promise<Located<{ [key in QS]: T }, RS>>;
 
 /**
  * A choreography is a function that takes a set of dependencies and a set of arguments and returns a set of results
  * @typeParam L - A set of possible locations
- * @typeParam Args - The types of the arguments. Must be an array of located values.
- * @typeParam Return - The types of the return values. Must be an array of located values.
+ * @typeParam Args - The types of the arguments.
+ * @typeParam Return - The types of the return values.
  * @param deps - The operators that can be used inside the choreography.
  * @param args - The arguments of the choreography.
  */
 export type Choreography<
   L extends Location,
-  Args extends Located<any, L>[] = [],
-  Return extends Located<any, L>[] = [],
+  Args = undefined,
+  Return = undefined,
 > = (deps: Dependencies<L>, args: Args) => Promise<Return>;
-
-/**
- * A utility to filter out the values not located at `L1` from an array of located values
- */
-export type LocatedElements<L extends Location, L1 extends L, A> = A extends [
-  Located<infer T, infer L2>,
-  ...infer TAIL,
-]
-  ? L2 extends L1
-    ? [T, ...LocatedElements<L, L1, TAIL>]
-    : [undefined, ...LocatedElements<L, L1, TAIL>]
-  : [];
-
-/**
- * A type-level utility to unwrap all located values to normal values
- */
-export type AllElements<A> = A extends [
-  Located<infer T, infer _>,
-  ...infer TAIL,
-]
-  ? [T, ...AllElements<TAIL>]
-  : [];
 
 /**
  * Represents a subscription that can be removed
@@ -291,22 +268,24 @@ export abstract class Transport<L extends Location, L1 extends L> {
 }
 
 export class Projector<L extends Location, L1 extends L> {
+  private key: symbol;
   private inbox: DefaultDict<string, IVar>;
   private subscription: Subscription | null;
   constructor(
     public transport: Transport<L, L1>,
     private target: L1
   ) {
+    this.key = Symbol(target.toString());
     this.inbox = new DefaultDict<string, IVar<Parcel<L>>>(() => new IVar());
     this.subscription = this.transport.subscribe((parcel) => {
-      const key = this.key(parcel.from, parcel.to, parcel.tag);
+      const key = this.getReceiveKey(parcel.from, parcel.to, parcel.tag);
       this.inbox.get(key).write(parcel);
     });
   }
   public destructor() {
     this.subscription?.remove();
   }
-  private key(src: L, dest: L, tag: Tag): string {
+  private getReceiveKey(src: L, dest: L, tag: Tag): string {
     return `${src.toString()}:${dest.toString()}:${tag.toString()}`;
   }
   private async sendTag(from: L, to: L, tag: Tag, data: any): Promise<void> {
@@ -319,25 +298,24 @@ export class Projector<L extends Location, L1 extends L> {
     await this.transport.send(parcel);
   }
   private async receiveTag(from: L, to: L, tag: Tag): Promise<any> {
-    const key = this.key(from, to, tag);
+    const key = this.getReceiveKey(from, to, tag);
     const parcel = await this.inbox.get(key).read();
     this.inbox.delete(key);
     return parcel.data;
   }
-  epp<Args extends Located<any, L>[], Return extends Located<any, L>[]>(
+  public epp<Args, Return>(
     choreography: Choreography<L, Args, Return>
-  ): (
-    args: LocatedElements<L, L1, Args>,
-    options?: { logManager?: LogManager }
-  ) => Promise<LocatedElements<L, L1, Return>> {
+  ): (args: Args, options?: { logManager?: LogManager }) => Promise<Return> {
     return async (args, options) => {
       const logManager = options?.logManager ?? new NotLogManager();
 
       const tag = new Tag();
-      const key = Symbol(this.target.toString());
+      const key = this.key;
       const ctxManager = new ContextManager<L>(this.transport.locations);
-      const locally: (_: Tag) => Locally<L> = (tag) => {
-        return async <L2 extends L, T>(
+      const locally: <X extends L>(_: Tag) => Locally<X> = <X extends L>(
+        tag: Tag
+      ) => {
+        return async <L2 extends X, T>(
           loc: L2,
           callback: (unwrap: Unwrap<L2>) => T | Promise<T>
         ) => {
@@ -364,12 +342,12 @@ export class Projector<L extends Location, L1 extends L> {
         };
       };
 
-      const comm: (t: Tag) => Comm<L> =
-        (t: Tag) =>
-        async <L1 extends L, L2 extends L, T>(
+      const comm: <X extends L>(t: Tag) => Comm<X> =
+        <X extends L>(t: Tag) =>
+        async <L1 extends X, L2 extends X, T>(
           sender: L1,
           receiver: L2,
-          value: Located<T, L1>
+          value: MultiplyLocated<T, L1>
         ) => {
           t.comm();
 
@@ -400,7 +378,7 @@ export class Projector<L extends Location, L1 extends L> {
             // if receiver, wait for value from sender and return
             const message: T = await this.receiveTag(sender, receiver, t);
             await logManager.write(t.toJSON(), message);
-            return new Located<T, L2>(message, key);
+            return new MultiplyLocated<T, L2>(message, key);
           }
           return undefined as any;
         };
@@ -424,39 +402,36 @@ export class Projector<L extends Location, L1 extends L> {
           return undefined as any;
         };
 
-      const fanout: (t: Tag) => FanOut<L> = (t: Tag) => async (qs, c) => {
-        const m: Record<string, any> = {};
-        for (const q of qs) {
-          const choreography = c(q);
-          const [located] = await call(t)(choreography, []);
-          // @ts-ignore
-          if (q === this.target) {
-            m[q] = located.getValueAt(q, key);
+      const fanout: <S extends L>(t: Tag) => FanOut<S> =
+        (t: Tag) => async (qs, c) => {
+          const m: Record<string, any> = {};
+          for (const q of qs) {
+            const choreography = c(q);
+            const located = await call(t)(choreography, undefined);
+            if ((q as string) === (this.target as string)) {
+              m[q] = located.getValueAt(q, key);
+            }
           }
-        }
-        return new Faceted(m, key);
-      };
+          return new Faceted(m, key);
+        };
 
-      const fanin: (t: Tag) => FanIn<L> = (t: Tag) => async (qs, rs, c) => {
-        const m: Record<string, any> = {};
-        for (const q of qs) {
-          const choreography = c(q);
-          const [located] = await call(t)(choreography, []);
-          // @ts-ignore
-          if (rs.includes(this.target)) {
-            m[q] = located.getValueAt(q, key);
+      const fanin: <S extends L>(t: Tag) => FanIn<S> =
+        (t: Tag) => async (qs, rs, c) => {
+          const m: Record<string, any> = {};
+          for (const q of qs) {
+            const choreography = c(q);
+            const v = await call(t)(choreography, []);
+            // @ts-ignore
+            if (rs.includes(this.target)) {
+              m[q] = v.getValueAt(q, key);
+            }
           }
-        }
-        return new Located(m as any, key);
-      };
+          return new Located(m as any, key);
+        };
 
       const enclave: (t: Tag) => Enclave<L> =
         (t: Tag) =>
-        async <
-          LL extends L,
-          Args extends Located<any, LL>[],
-          Return extends Located<any, LL>[],
-        >(
+        async <LL extends L, Args, Return>(
           locations: LL[],
           choreography: Choreography<LL, Args, Return>,
           args: Args
@@ -475,22 +450,14 @@ export class Projector<L extends Location, L1 extends L> {
                   call: call(childTag),
                   naked: (v) => v.getValueAt(this.target as any, key),
                   parallel: parallel(childTag),
-                  fanout: fanout(childTag),
-                  fanin: fanin(childTag),
+                  fanout: fanout<LL>(childTag),
+                  fanin: fanin<LL>(childTag),
                 }),
                 args
               );
               return ret;
             }
-            // any index of returned iterator may be accessed while the value will not be used.
-            // return a generator that returns undefined for each index
-            return {
-              *[Symbol.iterator]() {
-                for (;;) {
-                  yield undefined;
-                }
-              },
-            } as any;
+            return undefined as any;
           });
         };
 
@@ -499,7 +466,7 @@ export class Projector<L extends Location, L1 extends L> {
         async <L1 extends L, const LL extends L, T>(
           sender: L1,
           receivers: LL[],
-          value: Located<T, L1>
+          value: Located<T, L1> | MultiplyLocated<T, L1> | Faceted<T, L1>
         ) => {
           t.comm();
 
@@ -542,7 +509,10 @@ export class Projector<L extends Location, L1 extends L> {
 
       const broadcast: (t: Tag) => Broadcast<L> =
         (t: Tag) =>
-        async <L1 extends L, T>(sender: L1, value: Located<T, L1>) => {
+        async <S extends L, L1 extends L, T>(
+          sender: L1,
+          value: L1 extends S ? MultiplyLocated<T, S> : never
+        ) => {
           t.comm();
           // @ts-ignore
           if (this.target === sender) {
@@ -582,11 +552,7 @@ export class Projector<L extends Location, L1 extends L> {
 
       const call: (t: Tag) => Call<L> =
         (t: Tag) =>
-        async <
-          LL extends L,
-          Args extends Located<any, LL>[],
-          Return extends Located<any, LL>[],
-        >(
+        async <LL extends L, Args, Return>(
           c: Choreography<LL, Args, Return>,
           a: Args
         ) => {
@@ -610,7 +576,7 @@ export class Projector<L extends Location, L1 extends L> {
           );
         };
 
-      const naked: Naked<L> = <T>(cv: MultiplyLocated<T, L>) =>
+      const naked: Naked<L> = <S extends L, T>(cv: MultiplyLocated<T, S>) =>
         cv.getValueAt(this.target, key);
       const ret = await choreography(
         wrapMethods((m) => ctxManager.checkContext(m), {
@@ -625,12 +591,23 @@ export class Projector<L extends Location, L1 extends L> {
           fanout: fanout(tag),
           fanin: fanin(tag),
         }),
-        args.map((x) => new Located(x, key)) as any
+        args
       );
-      return ret.map((x) =>
-        x instanceof Located ? x.getValueAt(this.target, key) : undefined
-      ) as any;
+      return ret;
     };
+  }
+  public local<T>(value: T): MultiplyLocated<T, L1> {
+    return new MultiplyLocated(value, this.key);
+  }
+  public remote<T, X extends Location>(
+    _location: X
+  ): X extends L1 ? never : MultiplyLocated<T, X> {
+    return undefined as any;
+  }
+  public unwrap<T, S extends Location>(
+    located: L1 extends S ? MultiplyLocated<T, S> : never
+  ): T {
+    return located.getValue(this.key);
   }
 }
 
@@ -673,15 +650,15 @@ export class ContextManager<L extends Location> {
 }
 
 export class Runner {
-  public compile<
-    L extends Location,
-    Args extends Located<any, L>[],
-    Return extends Located<any, L>[],
-  >(
+  private key: symbol;
+  constructor() {
+    this.key = Symbol();
+  }
+  public compile<L extends Location, Args, Return>(
     choreography: Choreography<L, Args, Return>
-  ): (args: AllElements<Args>) => Promise<AllElements<Return>> {
+  ): (args: Args) => Promise<Return> {
     return async (args) => {
-      const key = Symbol();
+      const key = this.key;
       const locally: Locally<L> = async <L1 extends L, T>(
         loc: L1,
         callback: (unwrap: Unwrap<L1>) => T | Promise<T>
@@ -695,14 +672,14 @@ export class Runner {
         } else {
           v = retVal;
         }
-        return new Located(v, key);
+        return new MultiplyLocated(v, key);
       };
       const comm: Comm<L> = async <L1 extends L, L2 extends L, T>(
         sender: L1,
         _receiver: L2,
-        value: Located<T, L1>
+        value: MultiplyLocated<T, L1>
       ) => {
-        return new Located(value.getValue(key), key);
+        return new MultiplyLocated(value.getValue(key), key);
       };
       const parallel: Parallel<L> = async <const S extends L, T>(
         locations: S[],
@@ -718,36 +695,40 @@ export class Runner {
         await Promise.all(promises);
         return new Faceted(obj, key);
       };
-      const fanout: FanOut<L> = async <const S extends L, T>(
-        locations: S[],
-        c: <Q extends S>(loc: Q) => Choreography<L, [], [Located<T, Q>]>
-      ) => {
-        const m: Record<string, T> = {};
-        for (const q of locations) {
-          const choreography = c(q);
-          const [located] = await call(choreography, []);
-          m[q] = located.getValueAt(q, key);
-        }
-        return new Faceted(m, key);
-      };
-      const fanin: FanIn<L> = async <const QS extends L, const RS extends L, T>(
-        participants: QS[],
-        recipients: RS[],
-        c: <Q extends QS>(loc: Q) => Choreography<L, [], [Located<T, RS>]>
-      ) => {
-        const m: Record<string, T> = {};
-        for (const q of participants) {
-          const choreography = c(q);
-          const [located] = await call(choreography, []);
-          m[q] = located.getValueAt(q, key);
-        }
-        return new Located(m as any, key);
-      };
-      const enclave: Enclave<L> = async <
-        LL extends L,
-        Args extends Located<any, LL>[],
-        Return extends Located<any, LL>[],
-      >(
+      const fanout: <S extends L>() => FanOut<S> =
+        <S extends L>() =>
+        async <QS extends S, T>(
+          locations: QS[],
+          c: <Q extends QS>(
+            loc: Q
+          ) => Choreography<S, undefined, MultiplyLocated<T, QS>>
+        ) => {
+          const m: Record<string, T> = {};
+          for (const q of locations) {
+            const choreography = c(q);
+            const v = await call(choreography, undefined);
+            m[q] = v.getValueAt(q, key);
+          }
+          return new Faceted(m, key);
+        };
+      const fanin: <S extends L>() => FanIn<S> =
+        <S extends L>() =>
+        async <const QS extends S, const RS extends S, T>(
+          participants: QS[],
+          recipients: RS[],
+          c: <Q extends QS>(
+            loc: Q
+          ) => Choreography<S, [], MultiplyLocated<T, RS>>
+        ) => {
+          const m: Record<string, T> = {};
+          for (const q of participants) {
+            const choreography = c(q);
+            const v = await call(choreography, []);
+            m[q] = v.getValueAt(q, key);
+          }
+          return new Located(m as any, key);
+        };
+      const enclave: Enclave<L> = async <LL extends L, Args, Return>(
         locations: LL[],
         choreography: Choreography<LL, Args, Return>,
         args: Args
@@ -764,12 +745,12 @@ export class Runner {
             call: call,
             naked: naked,
             parallel: parallel,
-            fanout: fanout,
-            fanin: fanin,
+            fanout: fanout<LL>(),
+            fanin: fanin<LL>(),
           }),
           args
         );
-        return ret;
+        return new MultiplyLocated(ret, key);
       };
       const multicast: Multicast<L> = async <
         L1 extends L,
@@ -778,21 +759,17 @@ export class Runner {
       >(
         _sender: L1,
         _receivers: LL[],
-        value: Located<T, L1>
+        value: Located<T, L1> | MultiplyLocated<T, L1> | Faceted<T, L1>
       ) => {
         return new MultiplyLocated(value.getValueAt(_sender, key), key);
       };
-      const broadcast: Broadcast<L> = async <L1 extends L, T>(
+      const broadcast: Broadcast<L> = async <S extends L, L1 extends L, T>(
         _sender: L1,
-        value: Located<T, L1>
+        value: L1 extends S ? MultiplyLocated<T, S> : never
       ) => {
         return value.getValueAt(_sender, key);
       };
-      const call: Call<L> = async <
-        LL extends L,
-        Args extends Located<any, LL>[],
-        Return extends Located<any, LL>[],
-      >(
+      const call: Call<L> = async <LL extends L, Args, Return>(
         c: Choreography<LL, Args, Return>,
         a: Args
       ) => {
@@ -808,8 +785,8 @@ export class Runner {
             enclave: enclave,
             naked: naked,
             parallel,
-            fanout,
-            fanin,
+            fanout: fanout(),
+            fanin: fanin(),
           }),
           a
         );
@@ -828,32 +805,18 @@ export class Runner {
           enclave: enclave,
           naked: naked,
           parallel: parallel,
-          fanout: fanout,
-          fanin: fanin,
+          fanout: fanout(),
+          fanin: fanin(),
         },
-        args.map((x) => new Located(x, key)) as any
+        args
       );
-      return ret.map((x) =>
-        x instanceof Located ? x.getValue(key) : undefined
-      ) as any;
+      return ret;
     };
   }
+  public local<T, S extends Location>(value: T): MultiplyLocated<T, S> {
+    return new MultiplyLocated(value, this.key);
+  }
+  public unwrap<T, S extends Location>(value: MultiplyLocated<T, S>): T {
+    return value.getValue(this.key);
+  }
 }
-
-export const fanout_test: Choreography<
-  "alice" | "bob" | "carol",
-  [],
-  []
-> = async ({ locally, fanout }) => {
-  await fanout(
-    ["bob", "carol"],
-    <Q extends "bob" | "carol">(loc: Q) =>
-      async ({ locally, comm }) => {
-        const msgAtAlice = await locally("alice", () => `Hi ${loc}!`);
-        const msgAtLoc = await comm("alice", loc, msgAtAlice);
-        return [msgAtLoc];
-      }
-  );
-
-  return [];
-};

--- a/packages/core/src/core.ts
+++ b/packages/core/src/core.ts
@@ -366,7 +366,7 @@ export class Projector<L extends Location, L1 extends L> {
               const ret = await callback(loc, (located) =>
                 located.getValueAt(loc, key)
               );
-              return new Faceted({ loc: ret }, key);
+              return new Faceted({ [loc]: ret }, key);
             }
           }
           return undefined as any;

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -16,6 +16,7 @@ export type {
 export {
   Located,
   MultiplyLocated,
+  Faceted,
   Transport,
   Projector,
   Runner,

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -9,7 +9,6 @@ export type {
   Broadcast,
   Call,
   Choreography,
-  LocatedElements,
   Subscription,
   Parcel,
 } from "./core.js";

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -13,7 +13,6 @@ export type {
   Parcel,
 } from "./core.js";
 export {
-  Located,
   MultiplyLocated,
   Faceted,
   Transport,

--- a/packages/core/src/lib/transport-test-suite.ts
+++ b/packages/core/src/lib/transport-test-suite.ts
@@ -1,12 +1,6 @@
 import type { beforeAll, test, afterAll, expect } from "vitest";
 
-import {
-  Choreography,
-  Located,
-  MultiplyLocated,
-  Projector,
-  Transport,
-} from "..";
+import { Choreography, MultiplyLocated, Projector, Transport } from "..";
 import { InMemoryLogManager } from "../in-memory-log-manager";
 
 export namespace TransportTestSuite {

--- a/packages/core/src/lib/transport-test-suite.ts
+++ b/packages/core/src/lib/transport-test-suite.ts
@@ -1,6 +1,12 @@
 import type { beforeAll, test, afterAll, expect } from "vitest";
 
-import { Choreography, Located, Projector, Transport } from "..";
+import {
+  Choreography,
+  Located,
+  MultiplyLocated,
+  Projector,
+  Transport,
+} from "..";
 import { InMemoryLogManager } from "../in-memory-log-manager";
 
 export namespace TransportTestSuite {
@@ -23,7 +29,7 @@ export namespace TransportTestSuite {
   };
   export function transportTestSuite(
     factory: TransportFactory,
-    testFramework?: TestFramework,
+    testFramework?: TestFramework
   ) {
     const beforeAll =
       testFramework?.beforeAll ?? (globalThis as any)["beforeAll"];
@@ -85,9 +91,9 @@ export namespace TransportTestSuite {
     test("comm", async () => {
       const c: Choreography<
         Locations,
-        [Located<number, "alice">],
-        [Located<number, "dave">]
-      > = async ({ locally, comm }, [a]) => {
+        MultiplyLocated<number, "alice">,
+        MultiplyLocated<number, "dave">
+      > = async ({ locally, comm }, a) => {
         const a2 = await locally("alice", (unwrap) => {
           return unwrap(a) + 1;
         });
@@ -103,27 +109,27 @@ export namespace TransportTestSuite {
         const d2 = await locally("dave", (unwrap) => {
           return unwrap(d1) + 8;
         });
-        return [d2];
+        return d2;
       };
-      const [, , , [count]] = await Promise.all([
-        pa.epp(c)([0]),
-        pb.epp(c)([undefined]),
-        pc.epp(c)([undefined]),
-        pd.epp(c)([undefined]),
+      const [, , , count] = await Promise.all([
+        pa.epp(c)(pa.local(0)),
+        pb.epp(c)(pb.remote("alice")),
+        pc.epp(c)(pc.remote("alice")),
+        pd.epp(c)(pd.remote("alice")),
       ]);
-      expect(count).toEqual(15);
+      expect(pd.unwrap(count)).toEqual(15);
     });
     test("multicast", async () => {
       const test: Choreography<
         Locations,
-        [],
-        [Located<string, "bob">, Located<string, "carol">]
+        undefined,
+        [MultiplyLocated<string, "bob">, MultiplyLocated<string, "carol">]
       > = async ({ locally, multicast }) => {
         const msg = await locally("alice", () => "Hello, world!");
         const msgAtSelectedTwo = await multicast(
           "alice",
           ["carol", "bob"],
-          msg,
+          msg
         );
         const msgAtBob = await locally("bob", (unwrap) => {
           return unwrap(msgAtSelectedTwo);
@@ -134,13 +140,13 @@ export namespace TransportTestSuite {
         return [msgAtBob, msgAtCarol];
       };
       const [, [msgAtBob], [, msgAtCarol]] = await Promise.all([
-        pa.epp(test)([]),
-        pb.epp(test)([]),
-        pc.epp(test)([]),
-        pd.epp(test)([]),
+        pa.epp(test)(void 0),
+        pb.epp(test)(void 0),
+        pc.epp(test)(void 0),
+        pd.epp(test)(void 0),
       ]);
-      expect(msgAtBob).toEqual("Hello, world!");
-      expect(msgAtCarol).toEqual("Hello, world!");
+      expect(pb.unwrap(msgAtBob)).toEqual("Hello, world!");
+      expect(pc.unwrap(msgAtCarol)).toEqual("Hello, world!");
     });
     test("broadcast", async () => {
       let count = 0;
@@ -189,7 +195,7 @@ export namespace TransportTestSuite {
             count += 1;
             return [];
           },
-          [],
+          []
         );
         return [];
       };
@@ -213,13 +219,12 @@ export namespace TransportTestSuite {
           ["alice", "bob"],
           async () => {
             const _msgAtEveryone = await broadcast("carol", msgAtCarol);
-            return [];
           },
-          [],
+          undefined
         );
-        return [];
+        return undefined;
       };
-      const p = pa.epp(test)([]);
+      const p = pa.epp(test)(void 0);
       await expect(p).rejects.toThrow();
     });
 
@@ -228,8 +233,8 @@ export namespace TransportTestSuite {
       let crashed = false;
       const test: Choreography<
         Locations,
-        [],
-        [Located<number, "alice">]
+        undefined,
+        [MultiplyLocated<number, "alice">]
       > = async ({ locally, comm }) => {
         const a1 = await locally("alice", () => {
           return 100;
@@ -246,10 +251,10 @@ export namespace TransportTestSuite {
         return [a2];
       };
       const [la, lb] = [new InMemoryLogManager(), new InMemoryLogManager()];
-      const alice = pa.epp(test)([], { logManager: la });
-      let bob = pb.epp(test)([], { logManager: lb });
+      const alice = pa.epp(test)(void 0, { logManager: la });
+      let bob = pb.epp(test)(void 0, { logManager: lb });
       await expect(bob).rejects.toThrow("why!?");
-      bob = pb.epp(test)([], { logManager: lb });
+      bob = pb.epp(test)(void 0, { logManager: lb });
       await expect(bob).resolves.not.toThrow();
       await expect(alice).resolves.not.toThrow();
     });

--- a/packages/core/src/lib/transport-test-suite.ts
+++ b/packages/core/src/lib/transport-test-suite.ts
@@ -23,7 +23,7 @@ export namespace TransportTestSuite {
   };
   export function transportTestSuite(
     factory: TransportFactory,
-    testFramework?: TestFramework
+    testFramework?: TestFramework,
   ) {
     const beforeAll =
       testFramework?.beforeAll ?? (globalThis as any)["beforeAll"];
@@ -123,7 +123,7 @@ export namespace TransportTestSuite {
         const msgAtSelectedTwo = await multicast(
           "alice",
           ["carol", "bob"],
-          msg
+          msg,
         );
         const msgAtBob = await locally("bob", (unwrap) => {
           return unwrap(msgAtSelectedTwo);
@@ -189,7 +189,7 @@ export namespace TransportTestSuite {
             count += 1;
             return [];
           },
-          []
+          [],
         );
         return [];
       };
@@ -214,7 +214,7 @@ export namespace TransportTestSuite {
           async () => {
             const _msgAtEveryone = await broadcast("carol", msgAtCarol);
           },
-          undefined
+          undefined,
         );
         return undefined;
       };

--- a/packages/examples/package.json
+++ b/packages/examples/package.json
@@ -21,6 +21,7 @@
   "devDependencies": {
     "@choreography-ts/eslint-plugin-choreography-ts": "workspace:*",
     "get-port": "^7.0.0",
+    "tsx": "^4.19.2",
     "typescript": "^5.0.4",
     "vite": "^4.4.9"
   }

--- a/packages/examples/src/README.md
+++ b/packages/examples/src/README.md
@@ -1,3 +1,3 @@
 # Examples
 
-This folder contains example implementations of choreographic programs. To build them, run `tsc` in this folder to generate the `dist` build directory. Then invoke `node dist/<example folder>/<example>.js` to see the output for the specified example (e.g. `node dist/diffie-hellman/diffie-hellman.js alice`). You can also invoke `pnpm test` to test everything at once using the Vitest framework, which will run the `<example>.test.ts` unit test files.
+This folder contains example implementations of choreographic programs. Use `tsx` to execute examples (e.g., `pnpm tsx hello-world/hello-world`). You can also invoke `pnpm test` to test everything at once using the Vitest framework, which will run the `<example>.test.ts` unit test files.

--- a/packages/examples/src/bookseller/bookseller.test.ts
+++ b/packages/examples/src/bookseller/bookseller.test.ts
@@ -31,17 +31,17 @@ describe("bookseller", () => {
     ]);
   });
   it("buyer can buy TAPL", async () => {
-    const [[dateForTAPL]] = await Promise.all([
-      buyerProjector.epp(bookseller)(["TAPL"]),
-      sellerProjector.epp(bookseller)([undefined]),
+    const [dateForTAPL] = await Promise.all([
+      buyerProjector.epp(bookseller)(buyerProjector.local("TAPL")),
+      sellerProjector.epp(bookseller)(sellerProjector.remote("buyer")),
     ]);
-    expect(dateForTAPL).toBeTruthy();
+    expect(buyerProjector.unwrap(dateForTAPL)).toBeTruthy();
   });
   it("buyer cannot buy HoTT", async () => {
-    const [[dateForHoTT]] = await Promise.all([
-      buyerProjector.epp(bookseller)(["HoTT"]),
-      sellerProjector.epp(bookseller)([undefined]),
+    const [dateForHoTT] = await Promise.all([
+      buyerProjector.epp(bookseller)(buyerProjector.local("HoTT")),
+      sellerProjector.epp(bookseller)(sellerProjector.remote("buyer")),
     ]);
-    expect(dateForHoTT).toBeFalsy();
+    expect(buyerProjector.unwrap(dateForHoTT)).toBeFalsy();
   });
 });

--- a/packages/examples/src/bookseller/bookseller.ts
+++ b/packages/examples/src/bookseller/bookseller.ts
@@ -34,14 +34,14 @@ export const bookseller: Choreography<
   // seller looks up the price
   const priceAtSeller = await locally(
     "seller",
-    (unwrap) => priceTable.get(unwrap(titleAtSeller)) ?? Number("Infinity") // can't buy a book that doesn't exist
+    (unwrap) => priceTable.get(unwrap(titleAtSeller)) ?? Number("Infinity"), // can't buy a book that doesn't exist
   );
   // send the price back to the buyer
   const priceAtBuyer = await comm("seller", "buyer", priceAtSeller);
   // buyer decides whether to buy the book
   const decisionAtBuyer = await locally(
     "buyer",
-    (unwrap) => unwrap(priceAtBuyer) <= buyerBudget
+    (unwrap) => unwrap(priceAtBuyer) <= buyerBudget,
   );
   // broadcast the decision
   const decision = await broadcast("buyer", decisionAtBuyer);
@@ -50,17 +50,17 @@ export const bookseller: Choreography<
     const deliveryDateAtSeller = await locally(
       "seller",
       // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-      (unwrap) => deliveryDateTable.get(unwrap(titleAtSeller))!
+      (unwrap) => deliveryDateTable.get(unwrap(titleAtSeller))!,
     );
     // send the delivery date back to the buyer
     const deliveryDateAtBuyer = await comm(
       "seller",
       "buyer",
-      deliveryDateAtSeller
+      deliveryDateAtSeller,
     );
     await locally("buyer", (unwrap) => {
       console.log(
-        `Your book will be delivered on ${unwrap(deliveryDateAtBuyer)}`
+        `Your book will be delivered on ${unwrap(deliveryDateAtBuyer)}`,
       );
     });
     return deliveryDateAtBuyer;

--- a/packages/examples/src/fanin/fanin.ts
+++ b/packages/examples/src/fanin/fanin.ts
@@ -20,12 +20,12 @@ export const fanin_test: Choreography<Locations, [], []> = async ({
         const msgAtLoc = await locally(loc, () => `Hello from ${loc}!`);
         const msgAtAlice = await comm(loc, "alice", msgAtLoc);
         return msgAtAlice;
-      }
+      },
   );
   locally("alice", (unwrap) =>
     console.log(
-      `Bob said "${unwrap(m).bob}" and Carol said "${unwrap(m).carol}"`
-    )
+      `Bob said "${unwrap(m).bob}" and Carol said "${unwrap(m).carol}"`,
+    ),
   );
   return [];
 };

--- a/packages/examples/src/fanin/fanin.ts
+++ b/packages/examples/src/fanin/fanin.ts
@@ -1,11 +1,6 @@
 import esMain from "es-main";
 
-import {
-  Choreography,
-  Located,
-  Runner,
-  Projector,
-} from "@choreography-ts/core";
+import { Choreography, Projector } from "@choreography-ts/core";
 import {
   HttpConfig,
   ExpressTransport,
@@ -24,7 +19,7 @@ export const fanin_test: Choreography<Locations, [], []> = async ({
       async ({ locally, comm }) => {
         const msgAtLoc = await locally(loc, () => `Hello from ${loc}!`);
         const msgAtAlice = await comm(loc, "alice", msgAtLoc);
-        return [msgAtAlice];
+        return msgAtAlice;
       }
   );
   locally("alice", (unwrap) =>

--- a/packages/examples/src/fanout/fanout.ts
+++ b/packages/examples/src/fanout/fanout.ts
@@ -19,7 +19,7 @@ export const fanout_test: Choreography<Locations, [], []> = async ({
         const msgAtAlice = await locally("alice", () => `Hi ${loc}!`);
         const msgAtLoc = await comm("alice", loc, msgAtAlice);
         return msgAtLoc;
-      }
+      },
   );
   locally("bob", (unwrap) => {
     console.log(`Bob received: ${unwrap(x)}`);

--- a/packages/examples/src/fanout/fanout.ts
+++ b/packages/examples/src/fanout/fanout.ts
@@ -1,11 +1,6 @@
 import esMain from "es-main";
 
-import {
-  Choreography,
-  Located,
-  Runner,
-  Projector,
-} from "@choreography-ts/core";
+import { Choreography, Projector } from "@choreography-ts/core";
 import {
   HttpConfig,
   ExpressTransport,
@@ -19,13 +14,19 @@ export const fanout_test: Choreography<Locations, [], []> = async ({
 }) => {
   const x = await fanout(
     ["bob", "carol"],
-    <Q extends "bob" | "carol">(loc: Q) =>
+    (loc) =>
       async ({ locally, comm }) => {
         const msgAtAlice = await locally("alice", () => `Hi ${loc}!`);
         const msgAtLoc = await comm("alice", loc, msgAtAlice);
-        return [msgAtLoc];
+        return msgAtLoc;
       }
   );
+  locally("bob", (unwrap) => {
+    console.log(`Bob received: ${unwrap(x)}`);
+  });
+  locally("carol", (unwrap) => {
+    console.log(`Carol received: ${unwrap(x)}`);
+  });
   return [];
 };
 
@@ -49,8 +50,7 @@ async function main() {
   const bob = bobProjector.epp(fanout_test);
   const carol = carolProjector.epp(fanout_test);
 
-  const ret = await Promise.all([alice([]), bob([]), carol([])]);
-  console.log(ret);
+  await Promise.all([alice([]), bob([]), carol([])]);
   await Promise.all([
     aliceTransport.teardown(),
     bobTransport.teardown(),

--- a/packages/examples/src/lottery/finiteField.ts
+++ b/packages/examples/src/lottery/finiteField.ts
@@ -24,10 +24,6 @@ class Field {
     }
   }
 
-  multiply(a: number, b: number) {
-    return (a * b) % this.prime;
-  }
-
   rand() {
     return Math.floor(Math.random() * this.prime);
   }

--- a/packages/examples/src/lottery/finiteField.ts
+++ b/packages/examples/src/lottery/finiteField.ts
@@ -1,0 +1,33 @@
+// Generic finite field library that should be swapable with galois
+// Ididn't use galois due to issues with Bigint serialization
+// Just contains the operators we need for this example
+
+class Field {
+
+  prime: number;
+  zero = 0;
+
+  constructor(prime: number) {
+    this.prime = prime;
+  }
+
+  add(a: number, b: number) {
+    return (a + b) % this.prime;
+  }
+
+  sub(a: number, b: number) {
+    return (a - b + this.prime) % this.prime;
+  }
+
+  multiply(a: number, b: number) {
+    return (a * b) % this.prime;
+  }
+
+  rand() {
+    return Math.floor(Math.random() * this.prime);
+  }
+
+
+}
+
+export default Field;

--- a/packages/examples/src/lottery/finiteField.ts
+++ b/packages/examples/src/lottery/finiteField.ts
@@ -1,5 +1,5 @@
 // Generic finite field library that should be swapable with galois
-// Ididn't use galois due to issues with Bigint serialization
+// I didn't use galois due to issues with Bigint serialization
 // Just contains the operators we need for this example
 
 class Field {

--- a/packages/examples/src/lottery/finiteField.ts
+++ b/packages/examples/src/lottery/finiteField.ts
@@ -16,7 +16,12 @@ class Field {
   }
 
   sub(a: number, b: number) {
-    return (a - b + this.prime) % this.prime;
+    const x = (a - b) % this.prime;
+    if (x < 0) { // I think this is right
+      return x + this.prime;
+    } else {
+      return x;
+    }
   }
 
   multiply(a: number, b: number) {

--- a/packages/examples/src/lottery/finiteField.ts
+++ b/packages/examples/src/lottery/finiteField.ts
@@ -3,7 +3,6 @@
 // Just contains the operators we need for this example
 
 class Field {
-
   prime: number;
   zero = 0;
 
@@ -17,7 +16,8 @@ class Field {
 
   sub(a: number, b: number) {
     const x = (a - b) % this.prime;
-    if (x < 0) { // I think this is right
+    if (x < 0) {
+      // I think this is right
       return x + this.prime;
     } else {
       return x;
@@ -27,8 +27,6 @@ class Field {
   rand() {
     return Math.floor(Math.random() * this.prime);
   }
-
-
 }
 
 export default Field;

--- a/packages/examples/src/lottery/lottery.test.ts
+++ b/packages/examples/src/lottery/lottery.test.ts
@@ -11,7 +11,6 @@ import { lottery } from "./lottery";
 
 const servers = ["server1" as const, "server2" as const];
 const clients = ["client1" as const, "client2" as const];
-const analyst = "analyst" as const
 
 
 
@@ -71,8 +70,8 @@ describe("lottery", () => {
       analystProjector.epp(lottery(servers, clients, () => Promise.resolve("Not invoked")))(undefined),
     ]);
 
-    let i = (server1Secret + server2Secret) % clients.length;
-    let expectedAnswer = [client1Secret, client2Secret][i]
+    const i = (server1Secret + server2Secret) % clients.length;
+    const expectedAnswer = [client1Secret, client2Secret][i]
 
     expect(analystProjector.unwrap(analystAnswer)).toBe(expectedAnswer);
   });

--- a/packages/examples/src/lottery/lottery.test.ts
+++ b/packages/examples/src/lottery/lottery.test.ts
@@ -12,23 +12,36 @@ import { lottery } from "./lottery";
 const servers = ["server1" as const, "server2" as const];
 const clients = ["client1" as const, "client2" as const];
 
+let server1Projector: Projector<
+  "server1" | "server2" | "client1" | "client2" | "analyst",
+  "server1"
+>;
+let server2Projector: Projector<
+  "server1" | "server2" | "client1" | "client2" | "analyst",
+  "server2"
+>;
+let client1Projector: Projector<
+  "server1" | "server2" | "client1" | "client2" | "analyst",
+  "client1"
+>;
+let client2Projector: Projector<
+  "server1" | "server2" | "client1" | "client2" | "analyst",
+  "client2"
+>;
+let analystProjector: Projector<
+  "server1" | "server2" | "client1" | "client2" | "analyst",
+  "analyst"
+>;
 
-
-let server1Projector: Projector<"server1" | "server2" | "client1" | "client2" | "analyst", "server1">;
-let server2Projector: Projector<"server1" | "server2" | "client1" | "client2" | "analyst", "server2">;
-let client1Projector: Projector<"server1" | "server2" | "client1" | "client2" | "analyst", "client1">;
-let client2Projector: Projector<"server1" | "server2" | "client1" | "client2" | "analyst", "client2">;
-let analystProjector: Projector<"server1" | "server2" | "client1" | "client2" | "analyst", "analyst">;
-
-const config: HttpConfig<"server1" | "server2" | "client1" | "client2" | "analyst"> = {
+const config: HttpConfig<
+  "server1" | "server2" | "client1" | "client2" | "analyst"
+> = {
   server1: ["127.0.0.1", await getPort()],
   server2: ["127.0.0.1", await getPort()],
   client1: ["127.0.0.1", await getPort()],
   client2: ["127.0.0.1", await getPort()],
   analyst: ["127.0.0.1", await getPort()],
 };
-
-
 
 describe("lottery", () => {
   beforeAll(async () => {
@@ -46,32 +59,41 @@ describe("lottery", () => {
   });
   afterAll(async () => {
     await Promise.all([
-        server1Projector.transport.teardown(),
-        server2Projector.transport.teardown(),
-        client1Projector.transport.teardown(),
-        client2Projector.transport.teardown(),
-        analystProjector.transport.teardown(),
+      server1Projector.transport.teardown(),
+      server2Projector.transport.teardown(),
+      client1Projector.transport.teardown(),
+      client2Projector.transport.teardown(),
+      analystProjector.transport.teardown(),
     ]);
   });
   it("Test lottery", async () => {
-    
     const client1Secret = Math.floor(Math.random() * 999983);
     const client2Secret = Math.floor(Math.random() * 999983);
     const server1Secret = Math.floor(Math.random() * 10);
     const server2Secret = Math.floor(Math.random() * 10);
 
-    const asAnswer = (num: number) => () => Promise.resolve(num.toString())
+    const asAnswer = (num: number) => () => Promise.resolve(num.toString());
 
-    const [,,,,analystAnswer] = await Promise.all([
-      client1Projector.epp(lottery(servers, clients, asAnswer(client1Secret)))(undefined),
-      client2Projector.epp(lottery(servers, clients, asAnswer(client2Secret)))(undefined),
-      server1Projector.epp(lottery(servers, clients, asAnswer(server1Secret)))(undefined),
-      server2Projector.epp(lottery(servers, clients, asAnswer(server2Secret)))(undefined),
-      analystProjector.epp(lottery(servers, clients, () => Promise.resolve("Not invoked")))(undefined),
+    const [, , , , analystAnswer] = await Promise.all([
+      client1Projector.epp(lottery(servers, clients, asAnswer(client1Secret)))(
+        undefined,
+      ),
+      client2Projector.epp(lottery(servers, clients, asAnswer(client2Secret)))(
+        undefined,
+      ),
+      server1Projector.epp(lottery(servers, clients, asAnswer(server1Secret)))(
+        undefined,
+      ),
+      server2Projector.epp(lottery(servers, clients, asAnswer(server2Secret)))(
+        undefined,
+      ),
+      analystProjector.epp(
+        lottery(servers, clients, () => Promise.resolve("Not invoked")),
+      )(undefined),
     ]);
 
     const i = (server1Secret + server2Secret) % clients.length;
-    const expectedAnswer = [client1Secret, client2Secret][i]
+    const expectedAnswer = [client1Secret, client2Secret][i];
 
     expect(analystProjector.unwrap(analystAnswer)).toBe(expectedAnswer);
   });

--- a/packages/examples/src/lottery/lottery.test.ts
+++ b/packages/examples/src/lottery/lottery.test.ts
@@ -74,6 +74,6 @@ describe("lottery", () => {
     let i = (server1Secret + server2Secret) % servers.length;
     let expectedAnswer = [client1Secret, client2Secret][i]
 
-    expect(analystProjector.unwrap(analystAnswer)).toBe(expectedAnswer?.toString());
+    expect(analystProjector.unwrap(analystAnswer)).toBe(expectedAnswer);
   });
 });

--- a/packages/examples/src/lottery/lottery.test.ts
+++ b/packages/examples/src/lottery/lottery.test.ts
@@ -1,0 +1,67 @@
+import { describe, beforeAll, afterAll, expect, it } from "vitest";
+import getPort from "get-port";
+
+import {
+  ExpressTransport,
+  HttpConfig,
+} from "@choreography-ts/transport-express";
+import { Projector } from "@choreography-ts/core";
+
+import { lottery } from "./lottery";
+
+
+const servers = ["server1", "server2"]
+const clients = ["client1", "client2"]
+const analyst = "analyst"
+
+
+let server1Projector: Projector<"server1" | "server2" | "client1" | "client2" | "analyst", "server1">;
+let server2Projector: Projector<"server1" | "server2" | "client1" | "client2" | "analyst", "server2">;
+let client1Projector: Projector<"server1" | "server2" | "client1" | "client2" | "analyst", "client1">;
+let client2Projector: Projector<"server1" | "server2" | "client1" | "client2" | "analyst", "client2">;
+let analystProjector: Projector<"server1" | "server2" | "client1" | "client2" | "analyst", "analyst">;
+
+const config: HttpConfig<"server1" | "server2" | "client1" | "client2" | "analyst"> = {
+  server1: ["127.0.0.1", await getPort()],
+  server2: ["127.0.0.1", await getPort()],
+  client1: ["127.0.0.1", await getPort()],
+  client2: ["127.0.0.1", await getPort()],
+  analyst: ["127.0.0.1", await getPort()],
+};
+
+
+
+describe("lottery", () => {
+  beforeAll(async () => {
+    const server1Transport = await ExpressTransport.create(config, "server1");
+    const server2Transport = await ExpressTransport.create(config, "server2");
+    const client1Transport = await ExpressTransport.create(config, "client1");
+    const client2Transport = await ExpressTransport.create(config, "client2");
+    const analystTransport = await ExpressTransport.create(config, "analyst");
+
+    server1Projector = new Projector(server1Transport, "server1");
+    server2Projector = new Projector(server2Transport, "server2");
+    client1Projector = new Projector(client1Transport, "client1");
+    client2Projector = new Projector(client2Transport, "client2");
+    analystProjector = new Projector(analystTransport, "analyst");
+  });
+  afterAll(async () => {
+    await Promise.all([
+        server1Projector.transport.teardown(),
+        server2Projector.transport.teardown(),
+        client1Projector.transport.teardown(),
+        client2Projector.transport.teardown(),
+        analystProjector.transport.teardown(),
+    ]);
+  });
+  it("Test lottery", async () => {
+    const k = await Promise.all([
+      client1Projector.epp(lottery)([servers, clients]),
+      client2Projector.epp(lottery)([servers, clients]),
+      server1Projector.epp(lottery)([servers, clients]),
+      server2Projector.epp(lottery)([servers, clients]),
+      analystProjector.epp(lottery)([servers, clients]),
+    ]);
+    expect(true).toBeTruthy();
+  });
+});

--- a/packages/examples/src/lottery/lottery.test.ts
+++ b/packages/examples/src/lottery/lottery.test.ts
@@ -56,11 +56,11 @@ describe("lottery", () => {
   });
   it("Test lottery", async () => {
     const k = await Promise.all([
-      client1Projector.epp(lottery)([servers, clients]),
-      client2Projector.epp(lottery)([servers, clients]),
-      server1Projector.epp(lottery)([servers, clients]),
-      server2Projector.epp(lottery)([servers, clients]),
-      analystProjector.epp(lottery)([servers, clients]),
+      client1Projector.epp(lottery(servers, client)),
+      client2Projector.epp(lottery(servers, clients)),
+      server1Projector.epp(lottery(servers, clients)),
+      server2Projector.epp(lottery(servers, clients)),
+      analystProjector.epp(lottery(servers, clients)),
     ]);
     expect(true).toBeTruthy();
   });

--- a/packages/examples/src/lottery/lottery.test.ts
+++ b/packages/examples/src/lottery/lottery.test.ts
@@ -56,11 +56,10 @@ describe("lottery", () => {
   });
   it("Test lottery", async () => {
     
-    // TODO randomize this
-    const client1Secret = 42;
-    const client2Secret = 84;
-    const server1Secret = 2;
-    const server2Secret = 4;
+    const client1Secret = Math.floor(Math.random() * 999983);
+    const client2Secret = Math.floor(Math.random() * 999983);
+    const server1Secret = Math.floor(Math.random() * 10);
+    const server2Secret = Math.floor(Math.random() * 10);
 
     const asAnswer = (num: number) => () => Promise.resolve(num.toString())
 

--- a/packages/examples/src/lottery/lottery.test.ts
+++ b/packages/examples/src/lottery/lottery.test.ts
@@ -59,19 +59,20 @@ describe("lottery", () => {
     // TODO randomize this
     const client1Secret = 42;
     const client2Secret = 84;
-    const server1Secret = 3;
-    const server2Secret = 5;
+    const server1Secret = 2;
+    const server2Secret = 4;
 
     const asAnswer = (num: number) => () => Promise.resolve(num.toString())
+
     const [,,,,analystAnswer] = await Promise.all([
       client1Projector.epp(lottery(servers, clients, asAnswer(client1Secret)))(undefined),
       client2Projector.epp(lottery(servers, clients, asAnswer(client2Secret)))(undefined),
       server1Projector.epp(lottery(servers, clients, asAnswer(server1Secret)))(undefined),
       server2Projector.epp(lottery(servers, clients, asAnswer(server2Secret)))(undefined),
-      analystProjector.epp(lottery(servers, clients, () => Promise.resolve("")))(undefined),
+      analystProjector.epp(lottery(servers, clients, () => Promise.resolve("Not invoked")))(undefined),
     ]);
 
-    let i = (server1Secret + server2Secret) % servers.length;
+    let i = (server1Secret + server2Secret) % clients.length;
     let expectedAnswer = [client1Secret, client2Secret][i]
 
     expect(analystProjector.unwrap(analystAnswer)).toBe(expectedAnswer);

--- a/packages/examples/src/lottery/lottery.ts
+++ b/packages/examples/src/lottery/lottery.ts
@@ -1,0 +1,56 @@
+import { Choreography, Located, Projector } from "@choreography-ts/core";
+import {
+  HttpConfig,
+  ExpressTransport,
+} from "@choreography-ts/transport-express";
+
+// At least 2 servers and 2 clients
+// TODO How can I have arbitrary number of servers >=2
+// I made a few attempts going to keep them commented in case you all have any opinions
+
+/** Attempt 1
+const serverLocations_ = ["server1", "server2" ] as const;
+type ServerLocations_ = (typeof serverLocations_);
+type ServerLocations<serverTail extends [number]> = [...ServerLocations_, ...serverTail][number];
+
+type AtLeastTwo = [string, string, ...string[]];
+
+const clientLocations_ = [] as const;
+type ClientLocations_ = (typeof clientLocations_)[number];
+
+// There is only 1 analyst location
+const analystLocation_ = "analyst" as const;
+const AnalystLocation_ = typeof analystLocation_;
+
+const locations_ (serverLocations_ : string[]) => [analystLocation_, ...clientLocations_, ...serverLocations_] as const;
+type Locations_ = (typeof locations)[number];
+
+const locations = ["server1", "server2", "seller"] as const;
+export type Locations = (typeof locations)[number];
+*/
+
+// There is only 1 analyst location
+const analystLocation_ = "analyst" as const;
+type AnalystLocation_ = typeof analystLocation_;
+
+type FiniteField = number // TODO use some finite field library
+
+// Perhaps I can pass it in as an argument?
+export const lottery: (
+  serverLocations : ["server1", "server2", ...string[]], // Not sure if we really want ...string[]. I think we want to take a type param that we can union?
+  clientLocations : ["server1", "server2", ...string[]],
+) => Choreography<
+  ([... typeof serverLocations, ... typeof clientLocations, AnalystLocation_])[number],
+  [], // We don't have an argument in the original. The clients do generate a secret so that could be an argument.
+  [Located<FiniteField, "analyst">]
+> = (serverLocations, clientLocations) => {
+  const c: Choreography<
+  ([... typeof serverLocations, ... typeof clientLocations, AnalystLocation_])[number],
+  [],
+  [Located<FiniteField, "analyst">]> = async ({ locally, comm, multicast, colocally, call }, []) => {
+    // TODO implement
+    return 1;
+  }
+  // Do we need to do this
+  return c;
+}

--- a/packages/examples/src/lottery/lottery.ts
+++ b/packages/examples/src/lottery/lottery.ts
@@ -10,14 +10,17 @@ import {
 } from "@choreography-ts/transport-express";
 import esMain from "es-main";
 import readline from "readline";
-import { createHash } from 'node:crypto'
+import { createHash } from "node:crypto";
 import Field from "./finiteField";
 
 const field = new Field(999983);
 
 type FiniteField = number;
 
-const hash = (rho: number, psi: number) => createHash('sha256').update((rho + psi).toString()).digest('hex')
+const hash = (rho: number, psi: number) =>
+  createHash("sha256")
+    .update((rho + psi).toString())
+    .digest("hex");
 
 const rl = readline.createInterface({
   input: process.stdin,
@@ -29,16 +32,23 @@ function askQuestion(query: string): Promise<string> {
     rl.question(query, (ans) => {
       rl.close();
       resolve(ans);
-    })
+    }),
   );
 }
 
 const maxSalt = 2 ^ 18;
 const minSalt = 2 ^ 20;
 
-export const lottery = <SL extends Location, CL extends Location>(
-  serverLocations: SL[], clientLocations: CL[], askQuestion: (query: string) => Promise<string>
-): Choreography<"analyst" | SL | CL, undefined, MultiplyLocated<FiniteField, "analyst">> =>
+export const lottery =
+  <SL extends Location, CL extends Location>(
+    serverLocations: SL[],
+    clientLocations: CL[],
+    askQuestion: (query: string) => Promise<string>,
+  ): Choreography<
+    "analyst" | SL | CL,
+    undefined,
+    MultiplyLocated<FiniteField, "analyst">
+  > =>
   async ({ locally, fanin, fanout, parallel }) => {
     const secret = await parallel(clientLocations, async () => {
       const secretStr = await askQuestion("Secret: ");
@@ -46,9 +56,14 @@ export const lottery = <SL extends Location, CL extends Location>(
     });
 
     const clientShares = await parallel(clientLocations, async (_, unwrap) => {
-      const freeShares = Array.from({ length: serverLocations.length - 1 }, () => field.rand());
-      const lastShare = field.sub(unwrap(secret),
-        freeShares.reduce((a, b) => field.add(a, b), field.zero));
+      const freeShares = Array.from(
+        { length: serverLocations.length - 1 },
+        () => field.rand(),
+      );
+      const lastShare = field.sub(
+        unwrap(secret),
+        freeShares.reduce((a, b) => field.add(a, b), field.zero),
+      );
       const shares = freeShares.concat(lastShare);
       const serverToShares: Record<string, FiniteField> = {};
       for (const [index, server] of serverLocations.entries()) {
@@ -57,12 +72,22 @@ export const lottery = <SL extends Location, CL extends Location>(
       return serverToShares;
     });
 
-    const serverShares = await fanout(serverLocations, (server) =>
-      async ({ fanin }) => fanin(clientLocations, [server], (client) =>
-        async ({ locally, comm }) => {
-          const share = await locally(client, (unwrap) => unwrap(clientShares)[server]);
-          return comm(client, server, share);
-        })
+    const serverShares = await fanout(
+      serverLocations,
+      (server) =>
+        async ({ fanin }) =>
+          fanin(
+            clientLocations,
+            [server],
+            (client) =>
+              async ({ locally, comm }) => {
+                const share = await locally(
+                  client,
+                  (unwrap) => unwrap(clientShares)[server],
+                );
+                return comm(client, server, share);
+              },
+          ),
     );
 
     // 1) Each server selects a random number; τ is some multiple of the number of clients.
@@ -72,8 +97,9 @@ export const lottery = <SL extends Location, CL extends Location>(
     });
 
     // Salt value
-    const psi = await parallel(serverLocations, async () =>
-      Math.floor(Math.random() * (maxSalt - minSalt + 1)) + minSalt
+    const psi = await parallel(
+      serverLocations,
+      async () => Math.floor(Math.random() * (maxSalt - minSalt + 1)) + minSalt,
     );
 
     // 2) Each server computes and publishes the hash α = H(ρ, ψ) to serve as a commitment
@@ -83,22 +109,37 @@ export const lottery = <SL extends Location, CL extends Location>(
       return hash(rhoValue, psiValue);
     });
 
-    const alpha_ = await fanin(serverLocations, serverLocations, (server) =>
-      async ({ multicast }) => multicast(server, serverLocations, alpha)
+    const alpha_ = await fanin(
+      serverLocations,
+      serverLocations,
+      (server) =>
+        async ({ multicast }) =>
+          multicast(server, serverLocations, alpha),
     );
 
     // 3) Every server opens their commitments by publishing their ψ and ρ to each other
-    const psi_ = await fanin(serverLocations, serverLocations, (server) =>
-      async ({ multicast }) => multicast(server, serverLocations, psi)
+    const psi_ = await fanin(
+      serverLocations,
+      serverLocations,
+      (server) =>
+        async ({ multicast }) =>
+          multicast(server, serverLocations, psi),
     );
 
-    const rho_ = await fanin(serverLocations, serverLocations, (server) =>
-      async ({ multicast }) => multicast(server, serverLocations, rho)
+    const rho_ = await fanin(
+      serverLocations,
+      serverLocations,
+      (server) =>
+        async ({ multicast }) =>
+          multicast(server, serverLocations, rho),
     );
 
     // 4) All servers verify each other's commitment by checking α = H(ρ, ψ)
     await parallel(serverLocations, async (server, unwrap) => {
-      if (unwrap(alpha_)[server] != hash(unwrap(rho_)[server], unwrap(psi_)[server])) {
+      if (
+        unwrap(alpha_)[server] !=
+        hash(unwrap(rho_)[server], unwrap(psi_)[server])
+      ) {
         throw new Error("Commitment failed");
       }
     });
@@ -106,77 +147,101 @@ export const lottery = <SL extends Location, CL extends Location>(
     // 5) If all the checks are successful, then sum random values to get the random index.
     const omega = await parallel(serverLocations, async (_, unwrap) => {
       const randomValues = Object.values(unwrap(rho_)) as [FiniteField];
-      return randomValues.reduce((a, b) => field.add(a, b), field.zero) % clientLocations.length;
+      return (
+        randomValues.reduce((a, b) => field.add(a, b), field.zero) %
+        clientLocations.length
+      );
     });
 
-    const chosenShares = await parallel(serverLocations, async (_, unwrap) =>
-      Object.values(unwrap(serverShares))[unwrap(omega)] as FiniteField
+    const chosenShares = await parallel(
+      serverLocations,
+      async (_, unwrap) =>
+        Object.values(unwrap(serverShares))[unwrap(omega)] as FiniteField,
     );
 
     // Server sends the chosen shares to the analyst
-    const allShares = await fanin(serverLocations, ["analyst"], (server) =>
-      async ({ locally, comm }) => {
-        const chosenShares_ = await locally(server, (unwrap) => unwrap(chosenShares));
-        return comm(server, "analyst", chosenShares_);
-      });
+    const allShares = await fanin(
+      serverLocations,
+      ["analyst"],
+      (server) =>
+        async ({ locally, comm }) => {
+          const chosenShares_ = await locally(server, (unwrap) =>
+            unwrap(chosenShares),
+          );
+          return comm(server, "analyst", chosenShares_);
+        },
+    );
 
     return await locally("analyst", (unwrap) =>
-      Object.values(unwrap(allShares) as Record<string, FiniteField>)
-        .reduce((a, b) => field.add(a, b), field.zero));
+      Object.values(unwrap(allShares) as Record<string, FiniteField>).reduce(
+        (a, b) => field.add(a, b),
+        field.zero,
+      ),
+    );
   };
 
 async function main() {
   // Available roles to choose from
   const roles = ["server1", "server2", "client1", "client2", "analyst"];
 
-  rl.question(`Choose a role (1-5):\n  1) server1\n  2) server2\n  3) client1\n  4) client2\n  5) analyst\nEnter the number: `, async (roleNumber) => {
-    const index = parseInt(roleNumber, 10) - 1;
+  rl.question(
+    `Choose a role (1-5):\n  1) server1\n  2) server2\n  3) client1\n  4) client2\n  5) analyst\nEnter the number: `,
+    async (roleNumber) => {
+      const index = parseInt(roleNumber, 10) - 1;
 
-    if (index < 0 || index >= roles.length) {
-      console.log("Invalid choice. Please enter a number between 1 and 5.");
+      if (index < 0 || index >= roles.length) {
+        console.log("Invalid choice. Please enter a number between 1 and 5.");
+        rl.close();
+        return;
+      }
+
+      const chosenRole = roles[index];
+      if (chosenRole === undefined) {
+        console.log("Invalid choice. Please enter a number between 1 and 5.");
+        rl.close();
+        return;
+      }
+
+      type Locations =
+        | "server1"
+        | "server2"
+        | "client1"
+        | "client2"
+        | "analyst";
+      const config: HttpConfig<Locations> = {
+        server1: ["localhost", 3000],
+        server2: ["localhost", 3001],
+        client1: ["localhost", 3002],
+        client2: ["localhost", 3003],
+        analyst: ["localhost", 3004],
+      };
+
+      // Create transport for the chosen role
+      const transport = await ExpressTransport.create(
+        config,
+        chosenRole as Locations,
+      );
+      const projector = new Projector(transport, chosenRole as Locations);
+
+      // Instantiate the choreography with the chosen role
+      const lotteryChoreography = lottery(
+        ["server1", "server2"], // Servers involved in the choreography
+        ["client1", "client2"], // Clients involved in the choreography
+        askQuestion,
+      );
+
+      const answer = await projector.epp(lotteryChoreography)(void 0);
+      if (chosenRole === "analyst") {
+        console.log("The chosen number is: ", await projector.unwrap(answer));
+      }
+      console.log("done");
+
+      // Tear down the transport after use
+      await transport.teardown();
+
       rl.close();
-      return;
-    }
-
-    const chosenRole = roles[index];
-    if (chosenRole === undefined) {
-      console.log("Invalid choice. Please enter a number between 1 and 5.");
-      rl.close();
-      return;
-    }
-
-
-    type Locations = "server1" | "server2" | "client1" | "client2" | "analyst";
-    const config: HttpConfig<Locations> = {
-      server1: ["localhost", 3000],
-      server2: ["localhost", 3001],
-      client1: ["localhost", 3002],
-      client2: ["localhost", 3003],
-      analyst: ["localhost", 3004],
-    };
-
-    // Create transport for the chosen role
-    const transport = await ExpressTransport.create(config, chosenRole as Locations);
-    const projector = new Projector(transport, chosenRole as Locations);
-
-    // Instantiate the choreography with the chosen role
-    const lotteryChoreography = lottery(
-      ["server1", "server2"], // Servers involved in the choreography
-      ["client1", "client2"],  // Clients involved in the choreography
-      askQuestion
-    );
-
-    const answer = await projector.epp(lotteryChoreography)(void 0);
-    if (chosenRole === "analyst") {
-      console.log("The chosen number is: ", await projector.unwrap(answer));
-    }
-    console.log("done");
-
-    // Tear down the transport after use
-    await transport.teardown();
-
-    rl.close();
-  });
+    },
+  );
 }
 
 if (esMain(import.meta)) {

--- a/packages/examples/src/lottery/lottery.ts
+++ b/packages/examples/src/lottery/lottery.ts
@@ -10,12 +10,13 @@ import {
 } from "@choreography-ts/transport-express";
 import esMain from "es-main";
 import readline from "readline";
+import { createHash } from 'node:crypto'
 
 type FiniteField = number; // TODO use some finite field library
 
 const randomFp = () => Math.random();
 
-const hash = (rho: number, psi: number) => rho + psi; // TODO implement
+const hash = (rho: number, psi: number) => createHash('sha256').update((rho + psi).toString()).digest('hex')
 
 // https://stackoverflow.com/questions/18193953/waiting-for-user-to-enter-input-in-node-js
 function askQuestion(query: string): Promise<string> {
@@ -32,8 +33,6 @@ function askQuestion(query: string): Promise<string> {
   );
 }
 
-// Perhaps I can pass it in as an argument?
-// TODO also test this. Possibly new combinators (fanIn, fanOut, parallel) might have a bug
 export const lottery = <SL extends Location, CL extends Location>(
   serverLocations: SL[],
   clientLocations: CL[]

--- a/packages/examples/src/lottery/lottery.ts
+++ b/packages/examples/src/lottery/lottery.ts
@@ -47,11 +47,12 @@ export const lottery = <SL extends Location, CL extends Location>(
 
     const clientShares = await parallel(clientLocations, async (_, unwrap) => {
       const freeShares = Array.from({ length: serverLocations.length - 1 }, () => field.rand());
-      const lastShare = field.sub(unwrap(secret), freeShares.reduce((a, b) => field.add(a, b), field.zero));
+      const lastShare = field.sub(unwrap(secret),
+        freeShares.reduce((a, b) => field.add(a, b), field.zero));
       const shares = freeShares.concat(lastShare);
       const serverToShares: Record<string, FiniteField> = {};
       for (const [index, server] of serverLocations.entries()) {
-        serverToShares[server] = shares[index] as number
+        serverToShares[server] = shares[index] as FiniteField;
       }
       return serverToShares;
     });

--- a/packages/examples/src/lottery/lottery.ts
+++ b/packages/examples/src/lottery/lottery.ts
@@ -75,7 +75,6 @@ export const lottery = <SL extends Location, CL extends Location>(
               async ({ locally, comm }) => {
                 const share = await locally(client, (unwrap) => {
                   const dict = unwrap(clientShares);
-                  console.log({ dict });
                   const x = dict[server] as number;
                   return x;
                 });

--- a/packages/examples/src/lottery/lottery.ts
+++ b/packages/examples/src/lottery/lottery.ts
@@ -1,139 +1,190 @@
-import { Choreography, Located, Projector, Location, Faceted} from "@choreography-ts/core";
+import {
+  Choreography,
+  Projector,
+  Location,
+  Faceted,
+  MultiplyLocated,
+} from "@choreography-ts/core";
 import {
   HttpConfig,
   ExpressTransport,
 } from "@choreography-ts/transport-express";
-import readline from 'readline';
+import readline from "readline";
 
-type FiniteField = number // TODO use some finite field library
+type FiniteField = number; // TODO use some finite field library
 
 const randomFp = () => Math.random();
 
-const hash = (rho : number, psi : number) => 42; // TODO implement
+const hash = (rho: number, psi: number) => 42; // TODO implement
 
 // https://stackoverflow.com/questions/18193953/waiting-for-user-to-enter-input-in-node-js
 function askQuestion(query: string): Promise<string> {
-    const rl = readline.createInterface({
-        input: process.stdin,
-        output: process.stdout,
-    });
+  const rl = readline.createInterface({
+    input: process.stdin,
+    output: process.stdout,
+  });
 
-    return new Promise(resolve => rl.question(query, ans => {
-        rl.close();
-        resolve(ans);
-    }))
+  return new Promise((resolve) =>
+    rl.question(query, (ans) => {
+      rl.close();
+      resolve(ans);
+    })
+  );
 }
-
 
 // Perhaps I can pass it in as an argument?
 // TODO also test this. Possibly new combinators (fanIn, fanOut, parallel) might have a bug
 export const lottery = <SL extends Location, CL extends Location>(
-  serverLocations : SL[],
-  clientLocations : CL[]
-) : Choreography<
+  serverLocations: SL[],
+  clientLocations: CL[]
+): Choreography<
   "analyst" | SL | CL,
-  [],
-  [Located<FiniteField, "analyst">]
+  undefined,
+  MultiplyLocated<FiniteField, "analyst">
 > => {
   const c: Choreography<
-  "analyst" | SL | CL,
-  [Located<FiniteField, "analyst">]> = async ({ locally, comm, multicast, enclave, call, fanin, fanout, parallel }, []) => {
+    "analyst" | SL | CL,
+    undefined,
+    MultiplyLocated<FiniteField, "analyst">
+  > = async ({
+    locally,
+    comm,
+    multicast,
+    enclave,
+    call,
+    fanin,
+    fanout,
+    parallel,
+  }) => {
+    const secret = await parallel(clientLocations, async () => {
+      const secretStr = await askQuestion("Secret: ");
+      return parseInt(secretStr);
+    });
 
-      const secret = await parallel(clientLocations, async () => {
-        const secretStr = await askQuestion("Secret: ")
-        return parseInt(secretStr)
-      })
+    const clientShares = await parallel(clientLocations, async (_, unwrap) => {
+      const freeShares = Array.from({ length: serverLocations.length }, () =>
+        randomFp()
+      );
+      const serverToShares: Record<string, number> = {};
+      serverLocations.forEach((server, i) => {
+        serverToShares[server] =
+          unwrap(secret) - freeShares.reduce((a, b) => a + b, 0);
+      });
+      return serverToShares as Record<SL, FiniteField>;
+    });
 
-      const clientShares = await parallel(clientLocations, async (_ , unwrap) => {
-        const freeShares = Array.from({ length: serverLocations.length }, () => randomFp());
-        var serverToShares: any = {}
-        serverLocations.forEach((server, i) => {
-          serverToShares[server] = unwrap(secret) - freeShares.reduce((a, b) => a + b, 0);
-        });
-        return serverToShares as Record<SL, FiniteField>;
-      })
-
-      const serverShares : Faceted<{[client in CL]: FiniteField}, SL> = await fanout(serverLocations, <Server extends SL>(server : Server) => 
-        async ({ locally, fanin }) =>
-          [await fanin(clientLocations, [server], (client) => 
-              (async ({ locally, fanin }) => {
-                const serverShare: Located<FiniteField, typeof client> = await locally(client, (unwrap) => {
-                  let clientShare = unwrap(clientShares);
-                  return clientShare[server];
-                })
-                return [await comm(client, server, serverShare)]
-            })
-            )]
-        )
-
-      // 1) Each server selects a random number; τ is some multiple of the number of clients.
-      const rho = await parallel(serverLocations, async () => {
-        const tauStr = await askQuestion("Pick a number from 1 to tau:")
-        return parseInt(tauStr)
-      })
-
-      // Salt value
-      const psi = await parallel(serverLocations, async(server, unwrap) => {
-        const max = 2^18
-        const min = 2^20
-        return Math.floor(Math.random() * (max - min + 1)) + min;
-      })
-
-      // 2) Each server computes and publishes the hash α = H(ρ, ψ) to serve as a commitment
-      const alpha = await parallel(serverLocations, async(server, unwrap) => {
-        const rhoValue = unwrap(rho)
-        const psiValue = unwrap(psi)
-        return hash(rhoValue, psiValue)
-      })
-
-      const alpha_ = await fanin(serverLocations, serverLocations, (server) =>
-        async ({ comm }) => {
-          return comm(server, serverLocations, alpha)
+    const serverShares = await fanout(
+      serverLocations,
+      (server) =>
+        async ({ fanin }) => {
+          const shares = await fanin(
+            clientLocations,
+            [server],
+            <C extends CL>(client: C) =>
+              async ({ locally, comm }) => {
+                const share = await locally(client, (unwrap) => {
+                  const dict = unwrap(clientShares);
+                  const x = dict[server] as number;
+                  return x;
+                });
+                const share_ = await comm(client, server, share);
+                return share_;
+              }
+          );
+          return shares;
         }
-      )
+    );
 
-      // 3) Every server opens their commitments by publishing their ψ and ρ to each other
-      const psi_ = await fanin(serverLocations, serverLocations, (server) =>
-        async ({ comm }) => {
-          return comm(server, serverLocations, psi)
-      })
+    // 1) Each server selects a random number; τ is some multiple of the number of clients.
+    const rho = await parallel(serverLocations, async () => {
+      const tauStr = await askQuestion("Pick a number from 1 to tau:");
+      return parseInt(tauStr);
+    });
 
-      const rho_ : Located<{ [key in SL]: FiniteField }, SL> = await fanin(serverLocations, serverLocations, (server) =>
-        async ({ comm }) => {
-          return comm(server, serverLocations, rho)
-      })
+    // Salt value
+    const psi = await parallel(serverLocations, async () => {
+      const max = 2 ^ 18;
+      const min = 2 ^ 20;
+      return Math.floor(Math.random() * (max - min + 1)) + min;
+    });
 
-      // 4) All servers verify each other's commitment by checking α = H(ρ, ψ)
+    // 2) Each server computes and publishes the hash α = H(ρ, ψ) to serve as a commitment
+    const alpha = await parallel(serverLocations, async (server, unwrap) => {
+      const rhoValue = unwrap(rho);
+      const psiValue = unwrap(psi);
+      return hash(rhoValue, psiValue);
+    });
 
-      await parallel(serverLocations, async (server, unwrap) => {
-        if (unwrap(alpha_) != hash(rho_, psi_)) {
-          throw new Error("Commitment failed")
+    const alpha_ = await fanin(
+      serverLocations,
+      serverLocations,
+      (server) =>
+        async ({ multicast }) => {
+          return await multicast(server, serverLocations, alpha);
         }
-      })
+    );
 
-      // 5) If all the checks are successful, then sum random values to get the random index.
-      const omega = await parallel(serverLocations, async (server, unwrap) => {
-        const temp = unwrap(rho_)
-        const temp2 = Object.values(temp) as [FiniteField]
-        return temp2.reduce((a, b) => a + b, 0) % clientLocations.length
-      })
-
-      const chosenShares = await parallel(serverLocations, async (server, unwrap) => 
-         Object.values(unwrap(serverShares))[unwrap(omega)]
-      )
-
-      // Server sends the chosen shares to the analyst
-      const allShares = fanin(serverLocations, ["analyst"], (server) => {
-        async ({ comm }) => {
-          return comm(server, "analyst", chosenShares)
+    // 3) Every server opens their commitments by publishing their ψ and ρ to each other
+    const psi_ = await fanin(
+      serverLocations,
+      serverLocations,
+      (server) =>
+        async ({ multicast }) => {
+          return multicast(server, serverLocations, psi);
         }
-      })
+    );
 
-      await locally("analyst", (unwrap) => {
-        console.log(`The answer is: ${Object.values(unwrap(allShares)).reduce((a, b) => a + b, 0)}`)
-      })
-      
-    return undefined;
-  }
+    const rho_: MultiplyLocated<{ [key in SL]: FiniteField }, SL> = await fanin(
+      serverLocations,
+      serverLocations,
+      (server) =>
+        async ({ multicast }) => {
+          return multicast(server, serverLocations, rho);
+        }
+    );
+
+    // 4) All servers verify each other's commitment by checking α = H(ρ, ψ)
+
+    await parallel(serverLocations, async (server, unwrap) => {
+      if (unwrap(alpha_) != hash(unwrap(rho_)[server], unwrap(psi_)[server])) {
+        throw new Error("Commitment failed");
+      }
+    });
+
+    // 5) If all the checks are successful, then sum random values to get the random index.
+    const omega = await parallel(serverLocations, async (server, unwrap) => {
+      const temp = unwrap(rho_);
+      const temp2 = Object.values(temp) as [FiniteField];
+      return temp2.reduce((a, b) => a + b, 0) % clientLocations.length;
+    });
+
+    const chosenShares = await parallel(
+      serverLocations,
+      async (server, unwrap) =>
+        Object.values(unwrap(serverShares))[unwrap(omega)]
+    );
+
+    // Server sends the chosen shares to the analyst
+    const allShares = await fanin(
+      serverLocations,
+      ["analyst"],
+      (server) =>
+        async ({ locally, comm }) => {
+          const c = await locally(server, (unwrap) => {
+            return unwrap(chosenShares);
+          });
+          return comm(server, "analyst", c);
+        }
+    );
+
+    const ans = await locally("analyst", (unwrap) => {
+      const ans = Object.values(
+        unwrap(allShares) as Record<string, number>
+      ).reduce((a, b) => a + b, 0);
+      console.log(`The answer is: ${ans}`);
+      return ans;
+    });
+    return ans;
+  };
   return c;
-}
+};

--- a/packages/examples/src/lottery/lottery.ts
+++ b/packages/examples/src/lottery/lottery.ts
@@ -1,4 +1,4 @@
-import { Choreography, Located, Projector, Location} from "@choreography-ts/core";
+import { Choreography, Located, Projector, Location, Faceted} from "@choreography-ts/core";
 import {
   HttpConfig,
   ExpressTransport,
@@ -9,6 +9,7 @@ type FiniteField = number // TODO use some finite field library
 const randomFp = () => Math.random();
 
 // Perhaps I can pass it in as an argument?
+// TODO also test this. Possibly new combinators (fanIn, fanOut, parallel) might have a bug
 export const lottery = <SL extends Location, CL extends Location>(
   serverLocations : SL[],
   clientLocations : CL[]
@@ -19,24 +20,39 @@ export const lottery = <SL extends Location, CL extends Location>(
 > => {
   const c: Choreography<
   "analyst" | SL | CL,
-  [Located<FiniteField, "analyst">]> = async ({ locally, comm, multicast, colocally, call }, []) => {
+  [Located<FiniteField, "analyst">]> = async ({ locally, comm, multicast, enclave, call, fanin, fanout, parallel }, []) => {
 
-      const secret = await locally(clientLocations, (unwrap) => {
+      const secret = await parallel(clientLocations, async (unwrap) => {
         return randomFp();
-      }
+      })
 
-      // TODO What's the analogue of parallel in choreography-ts?
-      const clientShares = await colocally(clientLocations, (unwrap) => {
-        const freeShares = Array.from({ length: n }, () => randomFp());
-        var serverToShares: Record<SL, FiniteField> = {};
+      const clientShares = await parallel(clientLocations, async (_ , unwrap) => {
+        const freeShares = Array.from({ length: serverLocations.length }, () => randomFp());
+        var serverToShares : any = {} // - Record<SL, FiniteField> = {};
         serverLocations.forEach((server, i) => {
-          serverToShares[server] = unwrap(secret) - sum(freeShares);
+          serverToShares[server] = unwrap(secret) - freeShares.reduce((a, b) => a + b, 0);
         });
         return serverToShares;
       })
-    // TODO implement
+
+      // Weird that Q extends is needed here
+      const serverShares : Faceted<[FiniteField], SL> = await fanout(serverLocations, <Server extends SL>(server : Server) => {
+        const c : Choreography<SL | CL | "analyst", [], [Located<[FiniteField], Server>]> = async ({ locally, fanin }) => {
+          // Temporary code to make it compile might not be the type we want
+          // const temp = undefined as any as Located<[FiniteField], Server>
+          // return [temp]
+          const temp : Located<[FiniteField], Server> = await fanin(clientLocations, serverLocations, async (client) => {
+              const c2 : Located<FiniteField, Server> = await locally(client, (unwrap) => {
+                let clientShare = unwrap(clientShares);
+                return clientShare[server];
+              })
+              return c2
+            })
+          return [temp]
+        }
+        return c
+        })
     return 1;
   }
-  // Do we need to do this
   return c;
 }

--- a/packages/examples/src/lottery/lottery.ts
+++ b/packages/examples/src/lottery/lottery.ts
@@ -39,7 +39,8 @@ function askQuestion(query: string): Promise<string> {
 
 export const lottery = <SL extends Location, CL extends Location>(
   serverLocations: SL[],
-  clientLocations: CL[]
+  clientLocations: CL[],
+  askQuestion: (query: string) => Promise<string>
 ): Choreography<
   "analyst" | SL | CL,
   undefined,
@@ -221,7 +222,8 @@ export const lottery = <SL extends Location, CL extends Location>(
     // Instantiate the choreography with the chosen role
     const lotteryChoreography = lottery(
       ["server1", "server2"], // Servers involved in the choreography
-      ["client1", "client2"]  // Clients involved in the choreography
+      ["client1", "client2"],  // Clients involved in the choreography
+      askQuestion
     );
 
     await projector.epp(lotteryChoreography)(void 0);

--- a/packages/examples/src/lottery/lottery.ts
+++ b/packages/examples/src/lottery/lottery.ts
@@ -1,53 +1,39 @@
-import { Choreography, Located, Projector } from "@choreography-ts/core";
+import { Choreography, Located, Projector, Location} from "@choreography-ts/core";
 import {
   HttpConfig,
   ExpressTransport,
 } from "@choreography-ts/transport-express";
 
-// At least 2 servers and 2 clients
-// TODO How can I have arbitrary number of servers >=2
-// I made a few attempts going to keep them commented in case you all have any opinions
-
-/** Attempt 1
-const serverLocations_ = ["server1", "server2" ] as const;
-type ServerLocations_ = (typeof serverLocations_);
-type ServerLocations<serverTail extends [number]> = [...ServerLocations_, ...serverTail][number];
-
-type AtLeastTwo = [string, string, ...string[]];
-
-const clientLocations_ = [] as const;
-type ClientLocations_ = (typeof clientLocations_)[number];
-
-// There is only 1 analyst location
-const analystLocation_ = "analyst" as const;
-const AnalystLocation_ = typeof analystLocation_;
-
-const locations_ (serverLocations_ : string[]) => [analystLocation_, ...clientLocations_, ...serverLocations_] as const;
-type Locations_ = (typeof locations)[number];
-
-const locations = ["server1", "server2", "seller"] as const;
-export type Locations = (typeof locations)[number];
-*/
-
-// There is only 1 analyst location
-const analystLocation_ = "analyst" as const;
-type AnalystLocation_ = typeof analystLocation_;
-
 type FiniteField = number // TODO use some finite field library
 
+const randomFp = () => Math.random();
+
 // Perhaps I can pass it in as an argument?
-export const lottery: (
-  serverLocations : ["server1", "server2", ...string[]], // Not sure if we really want ...string[]. I think we want to take a type param that we can union?
-  clientLocations : ["server1", "server2", ...string[]],
-) => Choreography<
-  ([... typeof serverLocations, ... typeof clientLocations, AnalystLocation_])[number],
-  [], // We don't have an argument in the original. The clients do generate a secret so that could be an argument.
-  [Located<FiniteField, "analyst">]
-> = (serverLocations, clientLocations) => {
-  const c: Choreography<
-  ([... typeof serverLocations, ... typeof clientLocations, AnalystLocation_])[number],
+export const lottery = <SL extends Location, CL extends Location>(
+  serverLocations : SL[],
+  clientLocations : CL[]
+) : Choreography<
+  "analyst" | SL | CL,
   [],
+  [Located<FiniteField, "analyst">]
+> => {
+  const c: Choreography<
+  "analyst" | SL | CL,
   [Located<FiniteField, "analyst">]> = async ({ locally, comm, multicast, colocally, call }, []) => {
+
+      const secret = await locally(clientLocations, (unwrap) => {
+        return randomFp();
+      }
+
+      // TODO What's the analogue of parallel in choreography-ts?
+      const clientShares = await colocally(clientLocations, (unwrap) => {
+        const freeShares = Array.from({ length: n }, () => randomFp());
+        var serverToShares: Record<SL, FiniteField> = {};
+        serverLocations.forEach((server, i) => {
+          serverToShares[server] = unwrap(secret) - sum(freeShares);
+        });
+        return serverToShares;
+      })
     // TODO implement
     return 1;
   }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -113,6 +113,9 @@ importers:
       get-port:
         specifier: ^7.0.0
         version: 7.0.0
+      tsx:
+        specifier: ^4.19.2
+        version: 4.19.2
       typescript:
         specifier: ^5.0.4
         version: 5.0.4
@@ -387,6 +390,15 @@ packages:
     dev: true
     optional: true
 
+  /@esbuild/aix-ppc64@0.23.1:
+    resolution: {integrity: sha512-6VhYk1diRqrhBAqpJEdjASR/+WVRtfjpqKuNw11cLiaWpAT/Uu+nokB+UJnevzy/P9C/ty6AOe0dwueMrGh/iQ==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [aix]
+    requiresBuild: true
+    dev: true
+    optional: true
+
   /@esbuild/android-arm64@0.18.20:
     resolution: {integrity: sha512-Nz4rJcchGDtENV0eMKUNa6L12zz2zBDXuhj/Vjh18zGqB44Bi7MBMSXjgunJgjRhCmKOjnPuZp4Mb6OKqtMHLQ==}
     engines: {node: '>=12'}
@@ -399,6 +411,15 @@ packages:
   /@esbuild/android-arm64@0.21.5:
     resolution: {integrity: sha512-c0uX9VAUBQ7dTDCjq+wdyGLowMdtR/GoC2U5IYk/7D1H1JYC0qseD7+11iMP2mRLN9RcCMRcjC4YMclCzGwS/A==}
     engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [android]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@esbuild/android-arm64@0.23.1:
+    resolution: {integrity: sha512-xw50ipykXcLstLeWH7WRdQuysJqejuAGPd30vd1i5zSyKK3WE+ijzHmLKxdiCMtH1pHz78rOg0BKSYOSB/2Khw==}
+    engines: {node: '>=18'}
     cpu: [arm64]
     os: [android]
     requiresBuild: true
@@ -423,6 +444,15 @@ packages:
     dev: true
     optional: true
 
+  /@esbuild/android-arm@0.23.1:
+    resolution: {integrity: sha512-uz6/tEy2IFm9RYOyvKl88zdzZfwEfKZmnX9Cj1BHjeSGNuGLuMD1kR8y5bteYmwqKm1tj8m4cb/aKEorr6fHWQ==}
+    engines: {node: '>=18'}
+    cpu: [arm]
+    os: [android]
+    requiresBuild: true
+    dev: true
+    optional: true
+
   /@esbuild/android-x64@0.18.20:
     resolution: {integrity: sha512-8GDdlePJA8D6zlZYJV/jnrRAi6rOiNaCC/JclcXpB+KIuvfBN4owLtgzY2bsxnx666XjJx2kDPUmnTtR8qKQUg==}
     engines: {node: '>=12'}
@@ -435,6 +465,15 @@ packages:
   /@esbuild/android-x64@0.21.5:
     resolution: {integrity: sha512-D7aPRUUNHRBwHxzxRvp856rjUHRFW1SdQATKXH2hqA0kAZb1hKmi02OpYRacl0TxIGz/ZmXWlbZgjwWYaCakTA==}
     engines: {node: '>=12'}
+    cpu: [x64]
+    os: [android]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@esbuild/android-x64@0.23.1:
+    resolution: {integrity: sha512-nlN9B69St9BwUoB+jkyU090bru8L0NA3yFvAd7k8dNsVH8bi9a8cUAUSEcEEgTp2z3dbEDGJGfP6VUnkQnlReg==}
+    engines: {node: '>=18'}
     cpu: [x64]
     os: [android]
     requiresBuild: true
@@ -459,6 +498,15 @@ packages:
     dev: true
     optional: true
 
+  /@esbuild/darwin-arm64@0.23.1:
+    resolution: {integrity: sha512-YsS2e3Wtgnw7Wq53XXBLcV6JhRsEq8hkfg91ESVadIrzr9wO6jJDMZnCQbHm1Guc5t/CdDiFSSfWP58FNuvT3Q==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [darwin]
+    requiresBuild: true
+    dev: true
+    optional: true
+
   /@esbuild/darwin-x64@0.18.20:
     resolution: {integrity: sha512-pc5gxlMDxzm513qPGbCbDukOdsGtKhfxD1zJKXjCCcU7ju50O7MeAZ8c4krSJcOIJGFR+qx21yMMVYwiQvyTyQ==}
     engines: {node: '>=12'}
@@ -471,6 +519,15 @@ packages:
   /@esbuild/darwin-x64@0.21.5:
     resolution: {integrity: sha512-se/JjF8NlmKVG4kNIuyWMV/22ZaerB+qaSi5MdrXtd6R08kvs2qCN4C09miupktDitvh8jRFflwGFBQcxZRjbw==}
     engines: {node: '>=12'}
+    cpu: [x64]
+    os: [darwin]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@esbuild/darwin-x64@0.23.1:
+    resolution: {integrity: sha512-aClqdgTDVPSEGgoCS8QDG37Gu8yc9lTHNAQlsztQ6ENetKEO//b8y31MMu2ZaPbn4kVsIABzVLXYLhCGekGDqw==}
+    engines: {node: '>=18'}
     cpu: [x64]
     os: [darwin]
     requiresBuild: true
@@ -495,6 +552,15 @@ packages:
     dev: true
     optional: true
 
+  /@esbuild/freebsd-arm64@0.23.1:
+    resolution: {integrity: sha512-h1k6yS8/pN/NHlMl5+v4XPfikhJulk4G+tKGFIOwURBSFzE8bixw1ebjluLOjfwtLqY0kewfjLSrO6tN2MgIhA==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [freebsd]
+    requiresBuild: true
+    dev: true
+    optional: true
+
   /@esbuild/freebsd-x64@0.18.20:
     resolution: {integrity: sha512-tgWRPPuQsd3RmBZwarGVHZQvtzfEBOreNuxEMKFcd5DaDn2PbBxfwLcj4+aenoh7ctXcbXmOQIn8HI6mCSw5MQ==}
     engines: {node: '>=12'}
@@ -507,6 +573,15 @@ packages:
   /@esbuild/freebsd-x64@0.21.5:
     resolution: {integrity: sha512-J95kNBj1zkbMXtHVH29bBriQygMXqoVQOQYA+ISs0/2l3T9/kj42ow2mpqerRBxDJnmkUDCaQT/dfNXWX/ZZCQ==}
     engines: {node: '>=12'}
+    cpu: [x64]
+    os: [freebsd]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@esbuild/freebsd-x64@0.23.1:
+    resolution: {integrity: sha512-lK1eJeyk1ZX8UklqFd/3A60UuZ/6UVfGT2LuGo3Wp4/z7eRTRYY+0xOu2kpClP+vMTi9wKOfXi2vjUpO1Ro76g==}
+    engines: {node: '>=18'}
     cpu: [x64]
     os: [freebsd]
     requiresBuild: true
@@ -531,6 +606,15 @@ packages:
     dev: true
     optional: true
 
+  /@esbuild/linux-arm64@0.23.1:
+    resolution: {integrity: sha512-/93bf2yxencYDnItMYV/v116zff6UyTjo4EtEQjUBeGiVpMmffDNUyD9UN2zV+V3LRV3/on4xdZ26NKzn6754g==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
   /@esbuild/linux-arm@0.18.20:
     resolution: {integrity: sha512-/5bHkMWnq1EgKr1V+Ybz3s1hWXok7mDFUMQ4cG10AfW3wL02PSZi5kFpYKrptDsgb2WAJIvRcDm+qIvXf/apvg==}
     engines: {node: '>=12'}
@@ -543,6 +627,15 @@ packages:
   /@esbuild/linux-arm@0.21.5:
     resolution: {integrity: sha512-bPb5AHZtbeNGjCKVZ9UGqGwo8EUu4cLq68E95A53KlxAPRmUyYv2D6F0uUI65XisGOL1hBP5mTronbgo+0bFcA==}
     engines: {node: '>=12'}
+    cpu: [arm]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@esbuild/linux-arm@0.23.1:
+    resolution: {integrity: sha512-CXXkzgn+dXAPs3WBwE+Kvnrf4WECwBdfjfeYHpMeVxWE0EceB6vhWGShs6wi0IYEqMSIzdOF1XjQ/Mkm5d7ZdQ==}
+    engines: {node: '>=18'}
     cpu: [arm]
     os: [linux]
     requiresBuild: true
@@ -567,6 +660,15 @@ packages:
     dev: true
     optional: true
 
+  /@esbuild/linux-ia32@0.23.1:
+    resolution: {integrity: sha512-VTN4EuOHwXEkXzX5nTvVY4s7E/Krz7COC8xkftbbKRYAl96vPiUssGkeMELQMOnLOJ8k3BY1+ZY52tttZnHcXQ==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
   /@esbuild/linux-loong64@0.18.20:
     resolution: {integrity: sha512-nXW8nqBTrOpDLPgPY9uV+/1DjxoQ7DoB2N8eocyq8I9XuqJ7BiAMDMf9n1xZM9TgW0J8zrquIb/A7s3BJv7rjg==}
     engines: {node: '>=12'}
@@ -579,6 +681,15 @@ packages:
   /@esbuild/linux-loong64@0.21.5:
     resolution: {integrity: sha512-uHf1BmMG8qEvzdrzAqg2SIG/02+4/DHB6a9Kbya0XDvwDEKCoC8ZRWI5JJvNdUjtciBGFQ5PuBlpEOXQj+JQSg==}
     engines: {node: '>=12'}
+    cpu: [loong64]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@esbuild/linux-loong64@0.23.1:
+    resolution: {integrity: sha512-Vx09LzEoBa5zDnieH8LSMRToj7ir/Jeq0Gu6qJ/1GcBq9GkfoEAoXvLiW1U9J1qE/Y/Oyaq33w5p2ZWrNNHNEw==}
+    engines: {node: '>=18'}
     cpu: [loong64]
     os: [linux]
     requiresBuild: true
@@ -603,6 +714,15 @@ packages:
     dev: true
     optional: true
 
+  /@esbuild/linux-mips64el@0.23.1:
+    resolution: {integrity: sha512-nrFzzMQ7W4WRLNUOU5dlWAqa6yVeI0P78WKGUo7lg2HShq/yx+UYkeNSE0SSfSure0SqgnsxPvmAUu/vu0E+3Q==}
+    engines: {node: '>=18'}
+    cpu: [mips64el]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
   /@esbuild/linux-ppc64@0.18.20:
     resolution: {integrity: sha512-WHPyeScRNcmANnLQkq6AfyXRFr5D6N2sKgkFo2FqguP44Nw2eyDlbTdZwd9GYk98DZG9QItIiTlFLHJHjxP3FA==}
     engines: {node: '>=12'}
@@ -615,6 +735,15 @@ packages:
   /@esbuild/linux-ppc64@0.21.5:
     resolution: {integrity: sha512-1hHV/Z4OEfMwpLO8rp7CvlhBDnjsC3CttJXIhBi+5Aj5r+MBvy4egg7wCbe//hSsT+RvDAG7s81tAvpL2XAE4w==}
     engines: {node: '>=12'}
+    cpu: [ppc64]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@esbuild/linux-ppc64@0.23.1:
+    resolution: {integrity: sha512-dKN8fgVqd0vUIjxuJI6P/9SSSe/mB9rvA98CSH2sJnlZ/OCZWO1DJvxj8jvKTfYUdGfcq2dDxoKaC6bHuTlgcw==}
+    engines: {node: '>=18'}
     cpu: [ppc64]
     os: [linux]
     requiresBuild: true
@@ -639,6 +768,15 @@ packages:
     dev: true
     optional: true
 
+  /@esbuild/linux-riscv64@0.23.1:
+    resolution: {integrity: sha512-5AV4Pzp80fhHL83JM6LoA6pTQVWgB1HovMBsLQ9OZWLDqVY8MVobBXNSmAJi//Csh6tcY7e7Lny2Hg1tElMjIA==}
+    engines: {node: '>=18'}
+    cpu: [riscv64]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
   /@esbuild/linux-s390x@0.18.20:
     resolution: {integrity: sha512-+8231GMs3mAEth6Ja1iK0a1sQ3ohfcpzpRLH8uuc5/KVDFneH6jtAJLFGafpzpMRO6DzJ6AvXKze9LfFMrIHVQ==}
     engines: {node: '>=12'}
@@ -651,6 +789,15 @@ packages:
   /@esbuild/linux-s390x@0.21.5:
     resolution: {integrity: sha512-zus5sxzqBJD3eXxwvjN1yQkRepANgxE9lgOW2qLnmr8ikMTphkjgXu1HR01K4FJg8h1kEEDAqDcZQtbrRnB41A==}
     engines: {node: '>=12'}
+    cpu: [s390x]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@esbuild/linux-s390x@0.23.1:
+    resolution: {integrity: sha512-9ygs73tuFCe6f6m/Tb+9LtYxWR4c9yg7zjt2cYkjDbDpV/xVn+68cQxMXCjUpYwEkze2RcU/rMnfIXNRFmSoDw==}
+    engines: {node: '>=18'}
     cpu: [s390x]
     os: [linux]
     requiresBuild: true
@@ -675,6 +822,15 @@ packages:
     dev: true
     optional: true
 
+  /@esbuild/linux-x64@0.23.1:
+    resolution: {integrity: sha512-EV6+ovTsEXCPAp58g2dD68LxoP/wK5pRvgy0J/HxPGB009omFPv3Yet0HiaqvrIrgPTBuC6wCH1LTOY91EO5hQ==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
   /@esbuild/netbsd-x64@0.18.20:
     resolution: {integrity: sha512-iO1c++VP6xUBUmltHZoMtCUdPlnPGdBom6IrO4gyKPFFVBKioIImVooR5I83nTew5UOYrk3gIJhbZh8X44y06A==}
     engines: {node: '>=12'}
@@ -693,6 +849,24 @@ packages:
     dev: true
     optional: true
 
+  /@esbuild/netbsd-x64@0.23.1:
+    resolution: {integrity: sha512-aevEkCNu7KlPRpYLjwmdcuNz6bDFiE7Z8XC4CPqExjTvrHugh28QzUXVOZtiYghciKUacNktqxdpymplil1beA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [netbsd]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@esbuild/openbsd-arm64@0.23.1:
+    resolution: {integrity: sha512-3x37szhLexNA4bXhLrCC/LImN/YtWis6WXr1VESlfVtVeoFJBRINPJ3f0a/6LV8zpikqoUg4hyXw0sFBt5Cr+Q==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openbsd]
+    requiresBuild: true
+    dev: true
+    optional: true
+
   /@esbuild/openbsd-x64@0.18.20:
     resolution: {integrity: sha512-e5e4YSsuQfX4cxcygw/UCPIEP6wbIL+se3sxPdCiMbFLBWu0eiZOJ7WoD+ptCLrmjZBK1Wk7I6D/I3NglUGOxg==}
     engines: {node: '>=12'}
@@ -705,6 +879,15 @@ packages:
   /@esbuild/openbsd-x64@0.21.5:
     resolution: {integrity: sha512-HLNNw99xsvx12lFBUwoT8EVCsSvRNDVxNpjZ7bPn947b8gJPzeHWyNVhFsaerc0n3TsbOINvRP2byTZ5LKezow==}
     engines: {node: '>=12'}
+    cpu: [x64]
+    os: [openbsd]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@esbuild/openbsd-x64@0.23.1:
+    resolution: {integrity: sha512-aY2gMmKmPhxfU+0EdnN+XNtGbjfQgwZj43k8G3fyrDM/UdZww6xrWxmDkuz2eCZchqVeABjV5BpildOrUbBTqA==}
+    engines: {node: '>=18'}
     cpu: [x64]
     os: [openbsd]
     requiresBuild: true
@@ -729,6 +912,15 @@ packages:
     dev: true
     optional: true
 
+  /@esbuild/sunos-x64@0.23.1:
+    resolution: {integrity: sha512-RBRT2gqEl0IKQABT4XTj78tpk9v7ehp+mazn2HbUeZl1YMdaGAQqhapjGTCe7uw7y0frDi4gS0uHzhvpFuI1sA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [sunos]
+    requiresBuild: true
+    dev: true
+    optional: true
+
   /@esbuild/win32-arm64@0.18.20:
     resolution: {integrity: sha512-ddYFR6ItYgoaq4v4JmQQaAI5s7npztfV4Ag6NrhiaW0RrnOXqBkgwZLofVTlq1daVTQNhtI5oieTvkRPfZrePg==}
     engines: {node: '>=12'}
@@ -741,6 +933,15 @@ packages:
   /@esbuild/win32-arm64@0.21.5:
     resolution: {integrity: sha512-Z0gOTd75VvXqyq7nsl93zwahcTROgqvuAcYDUr+vOv8uHhNSKROyU961kgtCD1e95IqPKSQKH7tBTslnS3tA8A==}
     engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [win32]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@esbuild/win32-arm64@0.23.1:
+    resolution: {integrity: sha512-4O+gPR5rEBe2FpKOVyiJ7wNDPA8nGzDuJ6gN4okSA1gEOYZ67N8JPk58tkWtdtPeLz7lBnY6I5L3jdsr3S+A6A==}
+    engines: {node: '>=18'}
     cpu: [arm64]
     os: [win32]
     requiresBuild: true
@@ -765,6 +966,15 @@ packages:
     dev: true
     optional: true
 
+  /@esbuild/win32-ia32@0.23.1:
+    resolution: {integrity: sha512-BcaL0Vn6QwCwre3Y717nVHZbAa4UBEigzFm6VdsVdT/MbZ38xoj1X9HPkZhbmaBGUD1W8vxAfffbDe8bA6AKnQ==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [win32]
+    requiresBuild: true
+    dev: true
+    optional: true
+
   /@esbuild/win32-x64@0.18.20:
     resolution: {integrity: sha512-kTdfRcSiDfQca/y9QIkng02avJ+NCaQvrMejlsB3RRv5sE9rRoeBPISaZpKxHELzRxZyLvNts1P27W3wV+8geQ==}
     engines: {node: '>=12'}
@@ -777,6 +987,15 @@ packages:
   /@esbuild/win32-x64@0.21.5:
     resolution: {integrity: sha512-tQd/1efJuzPC6rCFwEvLtci/xNFcTZknmXs98FYDfGE4wP9ClFV98nyKrzJKVPMhdDnjzLhdUyMX4PsQAPjwIw==}
     engines: {node: '>=12'}
+    cpu: [x64]
+    os: [win32]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@esbuild/win32-x64@0.23.1:
+    resolution: {integrity: sha512-BHpFFeslkWrXWyUPnbKm+xYYVYruCinGcftSBaa8zoF9hZO4BcSCFUvHVTtzpIY6YzUnYtuEhZ+C9iEXjxnasg==}
+    engines: {node: '>=18'}
     cpu: [x64]
     os: [win32]
     requiresBuild: true
@@ -2478,6 +2697,38 @@ packages:
       '@esbuild/win32-x64': 0.21.5
     dev: true
 
+  /esbuild@0.23.1:
+    resolution: {integrity: sha512-VVNz/9Sa0bs5SELtn3f7qhJCDPCF5oMEl5cO9/SSinpE9hbPVvxbd572HH5AKiP7WD8INO53GgfDDhRjkylHEg==}
+    engines: {node: '>=18'}
+    hasBin: true
+    requiresBuild: true
+    optionalDependencies:
+      '@esbuild/aix-ppc64': 0.23.1
+      '@esbuild/android-arm': 0.23.1
+      '@esbuild/android-arm64': 0.23.1
+      '@esbuild/android-x64': 0.23.1
+      '@esbuild/darwin-arm64': 0.23.1
+      '@esbuild/darwin-x64': 0.23.1
+      '@esbuild/freebsd-arm64': 0.23.1
+      '@esbuild/freebsd-x64': 0.23.1
+      '@esbuild/linux-arm': 0.23.1
+      '@esbuild/linux-arm64': 0.23.1
+      '@esbuild/linux-ia32': 0.23.1
+      '@esbuild/linux-loong64': 0.23.1
+      '@esbuild/linux-mips64el': 0.23.1
+      '@esbuild/linux-ppc64': 0.23.1
+      '@esbuild/linux-riscv64': 0.23.1
+      '@esbuild/linux-s390x': 0.23.1
+      '@esbuild/linux-x64': 0.23.1
+      '@esbuild/netbsd-x64': 0.23.1
+      '@esbuild/openbsd-arm64': 0.23.1
+      '@esbuild/openbsd-x64': 0.23.1
+      '@esbuild/sunos-x64': 0.23.1
+      '@esbuild/win32-arm64': 0.23.1
+      '@esbuild/win32-ia32': 0.23.1
+      '@esbuild/win32-x64': 0.23.1
+    dev: true
+
   /escalade@3.1.2:
     resolution: {integrity: sha512-ErCHMCae19vR8vQGe50xIsVomy19rg6gFu3+r3jkEO46suLMWBksvVyoGgQV+jOfl84ZSOSlmv6Gxa89PmTGmA==}
     engines: {node: '>=6'}
@@ -2937,6 +3188,12 @@ packages:
       call-bind: 1.0.7
       es-errors: 1.3.0
       get-intrinsic: 1.2.4
+    dev: true
+
+  /get-tsconfig@4.8.1:
+    resolution: {integrity: sha512-k9PN+cFBmaLWtVz29SkUoqU5O0slLuHJXt/2P+tMVFT+phsSGXGkp9t3rQIqdz0e+06EHNGs3oM6ZX1s2zHxRg==}
+    dependencies:
+      resolve-pkg-maps: 1.0.0
     dev: true
 
   /glob-parent@5.1.2:
@@ -4245,6 +4502,10 @@ packages:
     engines: {node: '>=8'}
     dev: true
 
+  /resolve-pkg-maps@1.0.0:
+    resolution: {integrity: sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==}
+    dev: true
+
   /resolve@1.22.8:
     resolution: {integrity: sha512-oKWePCxqpd6FlLvGV1VU0x7bkPmmCNolxzjMf4NczoDnQcIWrAF+cPtZn5i6n+RfD2d9i0tzpKnG6Yk168yIyw==}
     hasBin: true
@@ -4953,6 +5214,17 @@ packages:
     dependencies:
       tslib: 1.14.1
       typescript: 5.0.4
+    dev: true
+
+  /tsx@4.19.2:
+    resolution: {integrity: sha512-pOUl6Vo2LUq/bSa8S5q7b91cgNSjctn9ugq/+Mvow99qW6x/UZYwzxy/3NmqoT66eHYfCVvFvACC58UBPFf28g==}
+    engines: {node: '>=18.0.0'}
+    hasBin: true
+    dependencies:
+      esbuild: 0.23.1
+      get-tsconfig: 4.8.1
+    optionalDependencies:
+      fsevents: 2.3.3
     dev: true
 
   /turbo-darwin-64@1.13.4:


### PR DESCRIPTION
Implement the lottery example from MultiChor which has an arbitrary number of clients and servers >=2. 


## Reference Haskell implementation
```haskell
-- | Federated Lottery example from DPrio https://www.semanticscholar.org/paper/DPrio%3A-Efficient-Differential-Privacy-with-High-for-Keeler-Komlo/ae1b2a4e5beaaa850183ad37e0880bb70ae34f4e
lottery
  :: forall clients servers analyst census m _serv1 _serv2 _servTail _client1 _client2 _clientTail
   . ( KnownSymbols clients, KnownSymbols servers, KnownSymbol analyst, MonadIO m
     , (_serv1 ': _serv2 ': _servTail) ~ servers -- There must be at least be two servers
     , (_client1 ': _client2 ': _clientTail) ~ clients -- There must be at least be two clients
     )
  => Subset clients census -> Subset servers census -> Member analyst census
  -> Choreo census (CLI m) ()
lottery clients servers analyst = do
  secret <- _parallel clients (getInput @Fp "secret:")
  -- Rest of the implementation
  analyst `locally_` \un -> putOutput "The answer is:" $ sum $ un singleton allShares
...
```